### PR TITLE
Add in --merge-target option

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,7 @@
 ## 0.1.0 (???)
 
 - Add in support for reading template context from `.cookiecutter.json`. (See [#2](https://github.com/zillow/battenberg/pull/2))
-- Add in `--merge-target` CLI option. (See #???)
+- Add in `--merge-target` CLI option. (See [#4](https://github.com/zillow/battenberg/pull/4))
 - Expanded test coverage, added in CI/CD via Travis CI. (See #???)
 
 Prior to v0.1.0 `battenberg` was developed under the [`milhoja`](https://github.com/rmedaer/milhoja) project.

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ conflicts needed to be manually resolved for each upgrade merge. To minimize the
 Install a [Cookiecutter](https://github.com/audreyr/cookiecutter) template:
 
 ```bash
-battenberg [-C <root path>] [--verbose] install [-c v1.0.0] <cookiecutter template path/URL>
+battenberg [-O <root path>] [--verbose] install [--checkout v1.0.0] <cookiecutter template path/URL>
 ```
 
-* `-c` - Specifies a target reference (branch, tag or commit) from the cookiecutter template repo.
+* `--checkout` - Specifies a target reference (branch, tag or commit) from the cookiecutter template repo.
 * `-O` - Specifies an output folder path, defaults to the current directory.
 * `--verbose` - Enables extra debug logging.
 

--- a/README.md
+++ b/README.md
@@ -21,36 +21,28 @@ conflicts needed to be manually resolved for each upgrade merge. To minimize the
 
 ## Usage
 
-Install a [Cookiecutter](https://github.com/audreyr/cookiecutter)
-template on current directory:
+Install a [Cookiecutter](https://github.com/audreyr/cookiecutter) template:
 
-    ```bash
-    battenberg install <your cookiecutter>
-    ```
+```bash
+battenberg [-C <root path>] [--verbose] install [-c v1.0.0] <cookiecutter template path/URL>
+```
 
-Specify a target reference (branch, tag, commit):
+* `-c` - Specifies a target reference (branch, tag or commit) from the cookiecutter template repo.
+* `-O` - Specifies an output folder path, defaults to the current directory.
+* `--verbose` - Enables extra debug logging.
 
-    ```bash
-    battenberg install -c v1.0.0 <your cookiecutter>
-    ```
+Upgrade your repository with last version of a template:
 
-Show installed template:
+```bash
+battenberg upgrade [--no-input] [--context-file <context filename>] [--merge-target <branch, tag or commit>]
+```
 
-    ```bash
-    battenberg show
-    ```
+* `--context-file` - Specifies where to read in the template context from, defaults to `.cookiecutter.json`.
+* `--no-input` - Read in the template context from `--context-file` instead of asking the `cookiecutter` template questions again.
+* `--merge-target` - Specify where to merge the eventual template updates.
 
-Install a [Cookiecutter](https://github.com/audreyr/cookiecutter) template on your existing Git repository:
-
-    ```bash
-    battenberg -C <your repo path> install <your cookiecutter>
-    ```
-
-Upgrade your repository with last version of template:
-
-    ```bash
-    battenberg -C <your repo path> upgrade
-    ```
+    *Note: `--merge-target` is useful to set if you are a template owner but each cookiecut repo is owned independently. The value you pass*
+    *to `--merge-target` should be the source branch for a PR that'd target `master` in the cookiecut repo so they can approve any changes.*
 
 ## High-level design
 
@@ -71,30 +63,30 @@ should be used to resolve any conflicts between the upstream template and the sp
 
 To get set up run:
 
-    ```bash
-    python3 -m venv env
-    source env/bin/activate
+```bash
+python3 -m venv env
+source env/bin/activate
 
-    # Install in editable mode so you get the updates propagated.
-    pip install -e .
+# Install in editable mode so you get the updates propagated.
+pip install -e .
 
-    # If you want to be able to run tests & linting install via:
-    pip install -e ".[dev]"
-    ```
+# If you want to be able to run tests & linting install via:
+pip install -e ".[dev]"
+```
 
 Then to actually perform any operations just use the `battenberg` command which should now be on your `$PATH`.
 
 To run tests:
 
-    ```bash
-    pytest
-    ```
+```bash
+pytest
+```
 
 To run linting:
 
-    ```bash
-    flake8 --config flake8.cfg battenberg
-    ```
+```bash
+flake8 --config flake8.cfg battenberg
+```
 
 ## FAQ
 

--- a/battenberg/cli.py
+++ b/battenberg/cli.py
@@ -58,7 +58,7 @@ def main(ctx, o, verbose):
 @click.argument('template')
 @click.argument('extra_context', nargs=-1, callback=validate_extra_context)
 @click.option(
-    '-c',
+    '--checkout',
     help='branch, tag or commit to checkout',
     default='master'
 )
@@ -78,7 +78,7 @@ def install(ctx, template, **kwargs):
 @main.command()
 @click.argument('extra_context', nargs=-1, callback=validate_extra_context)
 @click.option(
-    '-c',
+    '--checkout',
     help='branch, tag or commit to checkout',
     default='master'
 )

--- a/battenberg/core.py
+++ b/battenberg/core.py
@@ -99,7 +99,6 @@ class Battenberg:
                 self.repo.branches.local.create(merge_target, self.repo.get(self.repo.head.target))
             self.repo.checkout(merge_target_ref)
 
-        # Analyze merge between template branch and our merge target.
         analysis, _ = self.repo.merge_analysis(branch.target, merge_target_ref)
 
         if analysis & GIT_MERGE_ANALYSIS_UP_TO_DATE:


### PR DESCRIPTION
At a high-level the `--merge-target` option adds a convenient mechanism for branching off the `HEAD` (usually `master`) of the project that's being updated. For example if you wanted to run `battenberg upgrade` on `pricing-triage` then it'd by default try to merge the changes back into `master`, this is fine but our flow is to then construct a PR that'd allow the Purchase ML team to approve the upgrade.

In practice this means you'd run: `battenberg upgrade --merge-target archetype-update`. You'd run create a PR from `archetype-update` -> `master` for the repo you're looking to upgrade (ie. `pricing-triage`).

![Screen Shot 2019-10-07 at 3 10 06 PM](https://user-images.githubusercontent.com/628146/66352571-a34f1f00-e914-11e9-9cff-6af4218848d8.png)

To generate this screenshot I ran:

```bash
cd /tmp
battenberg -O example-project install git@gitlab.zgtools.net:zillow-offers/zoml/ml-infrastructure/archetype.py-ml.git
cd example-project
# Add in the template context.
vi .cookiecutter.json
git add . && commit -m "Add cc.json"
battenberg upgrade --no-input --merge-target archetype-update --checkout archetypev1.1
```

Done:
- Resolves [ZOMLINFRA-406](https://zbrt.atl.zillow.net/browse/ZOMLINFRA-406).
- Also cleans up the usage docs and CLI interface some more.
- Deprecates the `show` command which is obsolete now we have the template context easily accessible via `.cookiecutter.json`.