### PR TITLE
Add in .travis.yml file to kick off automated builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ matrix:
       python: 3.6
     - name: "Python 3.7"
       python: 3.7
-    - name: "Python 3.8"
-      python: 3.8
 install: 
   - echo "Install starting"
   - pip3 install ".[dev]"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,7 @@ install:
 script:
   - echo "Script starting"
   - flake8 --config flake8.cfg battenberg
-  - pytest
+  - pytest --cov=battenberg
+  # Upload the code coverage report to codecov
+  - codecov
   - echo "Script ending"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ matrix:
   include:
     - name: "Python 3.6"
       python: 3.6
-    # - name: "Python 3.7"
-    #   python: 3.7
-    # - name: "Python 3.8"
-    #   python: 3.8
+    - name: "Python 3.7"
+      python: 3.7
+    - name: "Python 3.8"
+      python: 3.8
 install: 
   - echo "Install starting"
   - pip3 install ".[dev]"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: python
+matrix:
+  include:
+    - name: "Python 3.6"
+      python: 3.6
+    # - name: "Python 3.7"
+    #   python: 3.7
+    # - name: "Python 3.8"
+    #   python: 3.8
+install: 
+  - echo "Install starting"
+  - pip3 install ".[dev]"
+  - echo "Install ending"
+
+script:
+  - echo "Script starting"
+  - flake8 --config flake8.cfg battenberg
+  - pytest
+  - echo "Script ending"

--- a/README.md
+++ b/README.md
@@ -59,21 +59,6 @@ should be used to resolve any conflicts between the upstream template and the sp
 
 *This shows the repo structure immediately after running a `battenberg upgrade` command on the previously installed project*
 
-## High-level design
-
-At a high level `battenberg` attempts to provide a continuous history between the upstream template project and the cookiecut project. It does this by maintaining a disjoint `template`
-branch which `battenberg` attempts to keep in sync with the upstream template, it therefore will contain no project-specific changes beyond replacing the template values. Then changes
-to the `template` are incorporated into the `master` and other branches via a `git merge --allow-unrelated-histories` command for each template update pulled in. This merge commit
-should be used to resolve any conflicts between the upstream template and the specialized project.
-
-![A new project in battenberg](img/new.png)
-
-*This shows the repo structure immediately after running a `battenberg install <template>` command*
-
-![An updated project in battenberg](img/updated.png)
-
-*This shows the repo structure immediately after running a `battenberg upgrade` command on the previously installed project*
-
 ## Development
 
 To get set up run:
@@ -116,20 +101,6 @@ flake8 --config flake8.cfg battenberg
 
     A tribute to the shoulders this project stands on, [`cookiecutter`](https://github.com/cookiecutter/cookiecutter) &
     [`milhoja`](https://github.com/rmedaer/milhoja), and [a tasty cake](https://en.wikipedia.org/wiki/Battenberg_cake) in its own right.
-
-## FAQ
-
-* Why are you using a new `.cookiecutter.json` pattern instead of using the [`replay` pattern](https://cookiecutter.readthedocs.io/en/latest/advanced/replay.html)?
-
-    Frankly the implementation was quite convoluted to get the intentions of these features to align. With the `.cookiecutter.json` approach
-    we're intended for template state to live at the project level instead of at the user level which the `replay` functionality defaults to.
-    Overriding that behaviour, whilst possible was convoluted in the current `cookiecutter` API and would require upstream changes so instead
-    we decided against trying to align these features.
-
-* Why `battenberg`?
-
-    A tribute to the shoulders this project stands on, [`cookiecutter`](https://github.com/cookiecutter/cookiecutter) &
-    [`milhoja`](https://github.com/rmedaer/milhoja), and [a tasty cake](https://en.wikipedia.org/wiki/Battenberg_cake) in it's own right.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ conflicts needed to be manually resolved for each upgrade merge. To minimize the
 `generate_example` boolean flag which will disable including any example code, instead replacing implementation with a
 [`pass`](https://docs.python.org/3/reference/simple_stmts.html#the-pass-statement) for example.
 
+## Prerequistes
+
+It is assumed that your cookiecutter template contains a `.cookiecutter.json` file at the root directory, or you can override it's location by
+passing in `--context-file`. Please use the [`jsonify`](https://github.com/cookiecutter/cookiecutter/pull/791) Jinja2 extension to dump the
+`cookiecutter` template context to `.cookiecutter.json`.
+
+**Tip:** One problem `milhoja` has that as divergence between the cookiecutter template and the project itself increase as will the volume of
+conflicts needed to be manually resolved for each upgrade merge. To minimize these it is often advisable to fit templates with a
+`generate_example` boolean flag which will disable including any example code, instead replacing implementation with a [`pass`](https://docs.python.org/2.0/ref/pass.html) for example.
+
 ## Usage
 
 Install a [Cookiecutter](https://github.com/audreyr/cookiecutter) template:
@@ -58,6 +68,21 @@ should be used to resolve any conflicts between the upstream template and the sp
 ![An updated project in battenberg](img/updated.png)
 
 *This shows the repo structure immediately after running a `battenberg upgrade` command on the previously installed project*
+
+## High-level design
+
+At a high level `milhoja` attempts to provide a continuous history between the upstream template project and the cookiecut project. It does this by maintaining a disjoint `template`
+branch which `milhoja` attempts to keep in sync with the upstream template, it therefore will contain no project-specific changes beyond replacing the template values. Then changes
+to the `template` are incorporated into the `master` and other branches via a `git merge --allow-unrelated-histories` command for each template update pulled in. This merge commit
+should be used to resolve any conflicts between the upstream template and the specialized project.
+
+![A new project in milhoja](img/new.png)
+
+*This shows the repo structure immediately after running a `milhoja install <template>` command*
+
+![An updated project in milhoja](img/updated.png)
+
+*This shows the repo structure immediately after running a `milhoja upgrade` command on the previously installed project*
 
 ## Development
 
@@ -101,6 +126,15 @@ flake8 --config flake8.cfg battenberg
 
     A tribute to the shoulders this project stands on, [`cookiecutter`](https://github.com/cookiecutter/cookiecutter) &
     [`milhoja`](https://github.com/rmedaer/milhoja), and [a tasty cake](https://en.wikipedia.org/wiki/Battenberg_cake) in its own right.
+
+## FAQ
+
+* Why are you using a new `.cookiecutter.json` pattern instead of using the [`replay` pattern](https://cookiecutter.readthedocs.io/en/latest/advanced/replay.html)?
+
+    Frankly the implementation was quite convoluted to get the intentions of these features to align. With the `.cookiecutter.json` approach
+    we're intended for template state to live at the project level instead of at the user level which the `replay` functionality defaults to.
+    Overriding that behaviour, whilst possible was convoluted in the current `cookiecutter` API and would require upstream changes so instead
+    we decided against trying to align these features.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -19,16 +19,6 @@ conflicts needed to be manually resolved for each upgrade merge. To minimize the
 `generate_example` boolean flag which will disable including any example code, instead replacing implementation with a
 [`pass`](https://docs.python.org/3/reference/simple_stmts.html#the-pass-statement) for example.
 
-## Prerequistes
-
-It is assumed that your cookiecutter template contains a `.cookiecutter.json` file at the root directory, or you can override it's location by
-passing in `--context-file`. Please use the [`jsonify`](https://github.com/cookiecutter/cookiecutter/pull/791) Jinja2 extension to dump the
-`cookiecutter` template context to `.cookiecutter.json`.
-
-**Tip:** One problem `milhoja` has that as divergence between the cookiecutter template and the project itself increase as will the volume of
-conflicts needed to be manually resolved for each upgrade merge. To minimize these it is often advisable to fit templates with a
-`generate_example` boolean flag which will disable including any example code, instead replacing implementation with a [`pass`](https://docs.python.org/2.0/ref/pass.html) for example.
-
 ## Usage
 
 Install a [Cookiecutter](https://github.com/audreyr/cookiecutter) template:
@@ -71,18 +61,18 @@ should be used to resolve any conflicts between the upstream template and the sp
 
 ## High-level design
 
-At a high level `milhoja` attempts to provide a continuous history between the upstream template project and the cookiecut project. It does this by maintaining a disjoint `template`
-branch which `milhoja` attempts to keep in sync with the upstream template, it therefore will contain no project-specific changes beyond replacing the template values. Then changes
+At a high level `battenberg` attempts to provide a continuous history between the upstream template project and the cookiecut project. It does this by maintaining a disjoint `template`
+branch which `battenberg` attempts to keep in sync with the upstream template, it therefore will contain no project-specific changes beyond replacing the template values. Then changes
 to the `template` are incorporated into the `master` and other branches via a `git merge --allow-unrelated-histories` command for each template update pulled in. This merge commit
 should be used to resolve any conflicts between the upstream template and the specialized project.
 
-![A new project in milhoja](img/new.png)
+![A new project in battenberg](img/new.png)
 
-*This shows the repo structure immediately after running a `milhoja install <template>` command*
+*This shows the repo structure immediately after running a `battenberg install <template>` command*
 
-![An updated project in milhoja](img/updated.png)
+![An updated project in battenberg](img/updated.png)
 
-*This shows the repo structure immediately after running a `milhoja upgrade` command on the previously installed project*
+*This shows the repo structure immediately after running a `battenberg upgrade` command on the previously installed project*
 
 ## Development
 
@@ -135,6 +125,11 @@ flake8 --config flake8.cfg battenberg
     we're intended for template state to live at the project level instead of at the user level which the `replay` functionality defaults to.
     Overriding that behaviour, whilst possible was convoluted in the current `cookiecutter` API and would require upstream changes so instead
     we decided against trying to align these features.
+
+* Why `battenberg`?
+
+    A tribute to the shoulders this project stands on, [`cookiecutter`](https://github.com/cookiecutter/cookiecutter) &
+    [`milhoja`](https://github.com/rmedaer/milhoja), and [a tasty cake](https://en.wikipedia.org/wiki/Battenberg_cake) in it's own right.
 
 ## Credits
 

--- a/battenberg/cli.py
+++ b/battenberg/cli.py
@@ -3,7 +3,6 @@ import sys
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))  # noqa: E402
 
 
-import json
 import logging
 import click
 from cookiecutter.cli import validate_extra_context
@@ -37,7 +36,7 @@ logger.addHandler(handler)
 def main(ctx, o, verbose):
     """
     \f
-    
+
     Script entry point for Battenberg commands.
     Arguments:
         ctx -- CLI context.

--- a/battenberg/core.py
+++ b/battenberg/core.py
@@ -89,6 +89,7 @@ class Battenberg:
 
     def merge_template_branch(self, message: str, merge_target: str = None):
         branch = self.repo.lookup_branch(TEMPLATE_BRANCH)
+        merge_target_ref = self.resolve_merge_target(merge_target)
 
         merge_target_ref = 'HEAD'
         if merge_target is not None:
@@ -105,6 +106,10 @@ class Battenberg:
             logger.info('The branch is already up to date, no need to merge.')
 
         elif analysis & GIT_MERGE_ANALYSIS_FASTFORWARD or analysis & GIT_MERGE_ANALYSIS_NORMAL:
+
+            # Ensure we're merging into the right
+            self.repo.checkout(merge_target_ref)
+
             # Let's merge template changes using --allow-unrelated-histories. This will allow
             # the disjoint histories to be merged successfully. If you want to manually replicate
             # this option please run:

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,6 @@ setup(
     ],
     python_requires=">=3.6*",
     extras_require={
-        'dev': ['pytest', 'flake8']
+        'dev': ['pytest', 'pytest-cov', 'flake8', 'codecov']
     }
 )


### PR DESCRIPTION
Fixes: [ZOMLINFRA-405](https://zbrt.atl.zillow.net/browse/ZOMLINFRA-405)

Done:
- Adds in support for builds running on Travis CI for python 3.6 & 3.7.
- Each build will run `pytest`, `flake8` & `codecov`.
- Hooks up code coverage reporting to codecov.io so it's easier to add tests later on.