### PR TITLE
Add in forked cookiecutter dependency giving us strip_dir functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ To get set up run:
 python3 -m venv env
 source env/bin/activate
 
+# In the short term we're loading cookiecutter from a forked repo, we need an up-to-date pip version to get this dependency.
+pip install --upgrade pip
+
 # Install in editable mode so you get the updates propagated.
 pip install -e .
 

--- a/battenberg/core.py
+++ b/battenberg/core.py
@@ -166,6 +166,7 @@ class Battenberg:
                 replay=False,
                 overwrite_if_exists=True,
                 output_dir=worktree.path,
+                strip=True
             )
 
             # Stage changes
@@ -231,6 +232,7 @@ class Battenberg:
                 replay=False,
                 overwrite_if_exists=True,
                 output_dir=worktree.path,
+                strip=True
             )
 
             # Stage changes

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,9 @@ with io.open('battenberg/__init__.py', 'rt', encoding='utf8') as f:
 
 install_requires = [
     'Click>=6.0',
-    'cookiecutter>=1.6.0',
+    # We need the functionality provided by this branch. See this PR for more info:
+    # https://github.com/cookiecutter/cookiecutter/pull/907
+    'cookiecutter @ git+ssh://git@github.com/zillow/cookiecutter@strip_dir#egg=cookiecutter',
     # You'll also need to install libgit2 to get this to work.
     # See instructions here: https://www.pygit2.org/install.html
     'pygit2>=0.28.0'
@@ -24,11 +26,10 @@ install_requires = [
 setup(
     name='battenberg',
     version=version,
-    description="Mixing Cookiecutter and Git to ends up sticking to your finger.",
+    description="Providing updates to cookiecutter projects.",
     long_description=readme + '\n\n' + history,
-    author="Raphael Medaer",
-    author_email='raphael@medaer.me',
-    url='https://github.com/rmedaer/battenberg',
+    author="Zillow",
+    url='https://github.com/zillow/battenberg',
     packages=[
         'battenberg',
     ],

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ install_requires = [
     'Click>=6.0',
     # We need the functionality provided by this branch. See this PR for more info:
     # https://github.com/cookiecutter/cookiecutter/pull/907
-    'cookiecutter @ git+ssh://git@github.com/zillow/cookiecutter@strip_dir#egg=cookiecutter',
+    'cookiecutter @ https://github.com/zillow/cookiecutter/tarball/strip_dir',
     # You'll also need to install libgit2 to get this to work.
     # See instructions here: https://www.pygit2.org/install.html
     'pygit2>=0.28.0'


### PR DESCRIPTION
We need [this change](https://github.com/cookiecutter/cookiecutter/pull/907) to be applied upstream in `cookiecutter`, unfortunately given the nature of the change I haven't worked out a better way around this.

So to mitigate the impact of this in the short term I've made us a copy of the original [`rmedaer:pr/strip_dir`](https://github.com/rmedaer/cookiecutter/tree/pr/strip_dir) branch to a Zillow owned fork (see [`zillow:strip_dir`](https://github.com/zillow/cookiecutter/tree/strip_dir)) so it doesn't get modified underneath us causing a build failure.