### PR TITLE
Solve strip directories problem by moving files down a directory after coookiecutting

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 0.1.1 (2019-10-17)
+
+- Revert back to relying on mainline `cookiecutter` instead of Zillow fork. (See [#9](https://github.com/zillow/battenberg/pull/9))
+
 ## 0.1.0 (2019-10-10)
 
 - Add in support for reading template context from `.cookiecutter.json`. (See [#2](https://github.com/zillow/battenberg/pull/2))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# battenberg
+# Battenberg
 
 [![image](https://img.shields.io/pypi/v/battenberg.svg)](https://pypi.python.org/pypi/battenberg)
 [![image](https://img.shields.io/travis/zillow/battenberg.svg)](https://travis-ci.org/zillow/battenberg)
@@ -6,6 +6,14 @@
 Battenberg is a tool built atop of [Cookiecutter](https://github.com/audreyr/cookiecutter) to keep Cookiecut projects
 in sync with their parent templates. Under the hood, Battenberg relies on Git to manage the merging, diffing, and
 conflict resolution story. The first goal of Battenberg is to provide an *upgrade* feature to Cookiecutter.
+
+## Installation
+
+We publish `battenberg` to [PyPI](https://pypi.org/project/battenberg/) for easy consumption.
+
+```bash
+pip install battenberg
+```
 
 ## Prerequistes
 

--- a/battenberg/__init__.py
+++ b/battenberg/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 
 from battenberg.core import Battenberg

--- a/battenberg/cli.py
+++ b/battenberg/cli.py
@@ -93,9 +93,9 @@ def install(ctx, template, **kwargs):
     type=click.Path()
 )
 @click.option(
-    '--no-input', is_flag=True,
-    help='Do not prompt for parameters and only use cookiecutter.json '
-         'file content',
+    '--no-input',
+    is_flag=True,
+    help='Do not prompt for parameters and only use .cookiecutter.json file content',
 )
 @click.pass_context
 def upgrade(ctx, **kwargs):

--- a/battenberg/core.py
+++ b/battenberg/core.py
@@ -132,7 +132,7 @@ class Battenberg:
 
         # Create temporary worktree
         with TemporaryWorktree(self.repo, WORKTREE_NAME) as worktree:
-            cookiecutter_kwargs={
+            cookiecutter_kwargs = {
                 'template': template,
                 'checkout': checkout,
                 'no_input': no_input,
@@ -192,7 +192,7 @@ class Battenberg:
             branch = worktree.repo.lookup_branch(TEMPLATE_BRANCH)
             worktree.repo.set_head(branch.name)
 
-            cookiecutter_kwargs={
+            cookiecutter_kwargs = {
                 'template': template,
                 'checkout': checkout,
                 'no_input': no_input,

--- a/battenberg/core.py
+++ b/battenberg/core.py
@@ -166,7 +166,7 @@ class Battenberg:
         # Let's merge our changes into HEAD
         self.merge_template_branch(f'Installed template \'{template}\'')
 
-    def upgrade(self, checkout: str = 'master', extra_context: Dict = None, no_input: bool = False,
+    def upgrade(self, checkout: str = 'master', extra_context: Dict = None, no_input: bool = True,
                 merge_target: str = None, context_file: str = '.cookiecutter.json'):
         if extra_context is None:
             extra_context = {}

--- a/battenberg/core.py
+++ b/battenberg/core.py
@@ -1,6 +1,7 @@
 import os
 import json
 import logging
+import shutil
 from typing import Any, Dict
 
 from pygit2 import (
@@ -11,6 +12,7 @@ from pygit2 import (
 )
 from cookiecutter.main import cookiecutter
 from battenberg.errors import (
+    BattenbergException,
     MergeConflictException,
     TemplateConflictException,
     TemplateNotFoundException
@@ -31,8 +33,34 @@ class Battenberg:
     def is_installed(self) -> bool:
         return TEMPLATE_BRANCH in self.repo.listall_branches()
 
-    def get_context(self, context_file: str) -> Dict[str, Any]:
-        with open(os.path.join(self.repo.workdir, context_file)) as f:
+    def cookiecut(self, cookiecutter_kwargs: dict, worktree: TemporaryWorktree):
+        cookiecutter(
+            replay=False,
+            overwrite_if_exists=True,
+            output_dir=worktree.path,
+            **cookiecutter_kwargs
+        )
+
+        # Ensure the worktree looks as we'd expect.
+        NUM_RENDERED_DIRECTORIES = 2
+        worktree_ls = os.listdir(worktree.path)
+        if len(worktree_ls) != NUM_RENDERED_DIRECTORIES:
+            # There should only be ".git" & "{{cookiecutter.top_level_name}}" directories.
+            raise BattenbergException(
+                f'Unexpected file structure in temporary worktree: {worktree_ls}')
+
+        # Now to strip the level top level directory from the rendered template in the
+        # temporary worktree path.
+        rendered_template_dir = next(d for d in worktree_ls if d != '.git')
+        rendered_template_path = os.path.join(worktree.path, rendered_template_dir)
+        for file in os.listdir(rendered_template_path):
+            shutil.move(os.path.join(rendered_template_path, file), worktree.path)
+        else:
+            # Finally clean up the old rendered template path.
+            shutil.rmtree(rendered_template_path)
+
+    def get_context(self, context_file: str, base_path: str = None) -> Dict[str, Any]:
+        with open(os.path.join(base_path or self.repo.workdir, context_file)) as f:
             return json.load(f)
 
     def merge_template_branch(self, message: str, merge_target: str = None):
@@ -104,16 +132,13 @@ class Battenberg:
 
         # Create temporary worktree
         with TemporaryWorktree(self.repo, WORKTREE_NAME) as worktree:
-            cookiecutter(
-                template,
-                checkout,
-                no_input,
-                extra_context=extra_context,
-                replay=False,
-                overwrite_if_exists=True,
-                output_dir=worktree.path,
-                strip=True
-            )
+            cookiecutter_kwargs={
+                'template': template,
+                'checkout': checkout,
+                'no_input': no_input,
+                'extra_context': extra_context
+            }
+            self.cookiecut(cookiecutter_kwargs, worktree)
 
             # Stage changes
             worktree.repo.index.add_all()
@@ -167,16 +192,13 @@ class Battenberg:
             branch = worktree.repo.lookup_branch(TEMPLATE_BRANCH)
             worktree.repo.set_head(branch.name)
 
-            cookiecutter(
-                template,
-                checkout,
-                no_input,
-                extra_context=context,
-                replay=False,
-                overwrite_if_exists=True,
-                output_dir=worktree.path,
-                strip=True
-            )
+            cookiecutter_kwargs={
+                'template': template,
+                'checkout': checkout,
+                'no_input': no_input,
+                'extra_context': context
+            }
+            self.cookiecut(cookiecutter_kwargs, worktree)
 
             # Stage changes
             worktree.repo.index.read()

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,7 @@ with io.open('battenberg/__init__.py', 'rt', encoding='utf8') as f:
 
 install_requires = [
     'Click>=6.0',
-    # We need the functionality provided by this branch. See this PR for more info:
-    # https://github.com/cookiecutter/cookiecutter/pull/907
-    'cookiecutter @ https://github.com/zillow/cookiecutter/tarball/strip_dir',
+    'cookiecutter>=1.6.0',
     # You'll also need to install libgit2 to get this to work.
     # See instructions here: https://www.pygit2.org/install.html
     'pygit2>=0.28.0'


### PR DESCRIPTION
The reason [we forked `cookiecutter`](https://github.com/zillow/cookiecutter) was to apply [this PR](https://github.com/cookiecutter/cookiecutter/pull/907) to add in a "strip directory" feature. That feature stopped the template being rendered in the top-level directory (ie. `{{cookiecutter.project_name}}`) and instead delegated it down a directory to allow for upgrades to be applied to an existing project without needing to know the outside folder name.

This implementation achieves the same thing by essentially manually copying the files after generation but before they're merged into the `merge-target` branch :)

Closes [ZOMLINFRA-432](https://zbrt.atl.zillow.net/browse/ZOMLINFRA-432)

---

The alternative approach I thought about was including a locally forked copy of `cookiecutter` in this repo. The obvious downside of this approach is that it's a fork and we won't easily get `cookiecutter` upgrades, the benefits are that it's a fork and we can do whatever we want! 

I think either this solution in the PR or the local forking approaches were about the time to implement but the forking approach might be slightly less maintainable if `battenberg` doesn't propagate successfully, thus I took this approach!