### PR TITLE
AIPO-427: Improve merge conflicts error message

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 0.2.1 (2010-??-??)
+
+- Cleans up error message when merging results in conflicts. (See [#13](https://github.com/zillow/battenberg/pull/13))
+
 ## 0.2.0 (2019-10-29)
 
 - Adds in remote fetching of `origin/template` branch during upgrades. (See [#12](https://github.com/zillow/battenberg/pull/12))

--- a/battenberg/cli.py
+++ b/battenberg/cli.py
@@ -103,10 +103,11 @@ def upgrade(ctx, **kwargs):
     try:
         battenberg = Battenberg(open_repository(ctx.obj['target']))
         battenberg.upgrade(**kwargs)
-    except MergeConflictException as error:
+    except MergeConflictException:
         # Just run "git status" in a subprocess so we don't have to re-implement the formatting
         # logic atop pygit2.
-        completed_process = subprocess.run(['git', 'status'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        completed_process = subprocess.run(['git', 'status'], stdout=subprocess.PIPE,
+                                           stderr=subprocess.STDOUT)
         print(completed_process.stdout.decode('utf-8'))
         print('Cannot merge upgrade automatically, please manually resolve the conflicts')
     except (BattenbergException, CookiecutterException) as error:

--- a/battenberg/cli.py
+++ b/battenberg/cli.py
@@ -6,11 +6,9 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))  # noqa: E402
 import logging
 import subprocess
 import click
-from cookiecutter.cli import validate_extra_context
-from cookiecutter.exceptions import CookiecutterException
 from battenberg.core import Battenberg
 from battenberg.utils import open_repository, open_or_init_repository
-from battenberg.errors import BattenbergException, MergeConflictException
+from battenberg.errors import MergeConflictException
 
 
 logger = logging.getLogger('battenberg')
@@ -56,7 +54,6 @@ def main(ctx, o: str, verbose: bool):
 
 @main.command()
 @click.argument('template')
-@click.argument('extra_context', nargs=-1, callback=validate_extra_context)
 @click.option(
     '--checkout',
     help='branch, tag or commit to checkout',
@@ -68,15 +65,11 @@ def main(ctx, o: str, verbose: bool):
 )
 @click.pass_context
 def install(ctx, template: str, **kwargs):
-    try:
-        battenberg = Battenberg(open_or_init_repository(ctx.obj['target']))
-        battenberg.install(template, **kwargs)
-    except (BattenbergException, CookiecutterException) as error:
-        raise click.ClickException from error
+    battenberg = Battenberg(open_or_init_repository(ctx.obj['target']))
+    battenberg.install(template, **kwargs)
 
 
 @main.command()
-@click.argument('extra_context', nargs=-1, callback=validate_extra_context)
 @click.option(
     '--checkout',
     help='branch, tag or commit to checkout',
@@ -111,5 +104,3 @@ def upgrade(ctx, **kwargs):
         click.echo(completed_process.stdout.decode('utf-8'))
         click.echo('Cannot merge upgrade automatically, please manually resolve the conflicts')
         sys.exit(1)  # Ensure we exit with a failure code.
-    except (BattenbergException, CookiecutterException) as error:
-        raise click.ClickException from error

--- a/battenberg/cli.py
+++ b/battenberg/cli.py
@@ -108,7 +108,8 @@ def upgrade(ctx, **kwargs):
         # logic atop pygit2.
         completed_process = subprocess.run(['git', 'status'], stdout=subprocess.PIPE,
                                            stderr=subprocess.STDOUT)
-        print(completed_process.stdout.decode('utf-8'))
-        print('Cannot merge upgrade automatically, please manually resolve the conflicts')
+        click.echo(completed_process.stdout.decode('utf-8'))
+        click.echo('Cannot merge upgrade automatically, please manually resolve the conflicts')
+        sys.exit(1)  # Ensure we exit with a failure code.
     except (BattenbergException, CookiecutterException) as error:
         raise click.ClickException from error

--- a/battenberg/core.py
+++ b/battenberg/core.py
@@ -101,6 +101,8 @@ class Battenberg:
             # Ensure we're merging into the right
             self.repo.checkout(merge_target_ref)
 
+            import pdb; pdb.set_trace()
+
             # Let's merge template changes using --allow-unrelated-histories. This will allow
             # the disjoint histories to be merged successfully. If you want to manually replicate
             # this option please run:
@@ -146,19 +148,19 @@ class Battenberg:
 
         Args:
             template: The path (either local or git) to the template project. It must follow
-            the cookiecutter format to be compatible with battenberg.
+                the cookiecutter format to be compatible with battenberg.
             checkout: The new state to pull from the template, normally this will be a git tag on
-            the template repo.
+                the template repo.
             no_input: Whether to ask the user to answer the template questions again or take the
-            default answers from the templates "cookiecutter.json".
+                default answers from the templates "cookiecutter.json".
             extra_context: A set of template overrides that will supercede those found in the
-            "context_file" or those provided by answering the template questionnaire.
+                "context_file" or those provided by answering the template questionnaire.
 
         Raises:
             MergeConflictException: Thrown when an upgrade results in merge conflicts between the
-            template branch and the merge-target branch.
+                template branch and the merge-target branch.
             TemplateConflictException: When the repo already contains a template branch. If you
-            encounter this please run "battenberg upgrade" instead.
+                encounter this please run "battenberg upgrade" instead.
         """
 
         if extra_context is None:
@@ -214,20 +216,20 @@ class Battenberg:
 
         Args:
             checkout: The new state to pull from the template, normally this will be a git tag on
-            the template repo.
+                the template repo.
             no_input: Whether to ask the user to answer the template questions again or take the
-            answers from the template context defined in "context_file".
+                answers from the template context defined in "context_file".
             merge_target: A branch to checkout other than the current HEAD. Useful if you're
-            upgrading a project you do not directly own.
+                upgrading a project you do not directly own.
             context_file: Where battenberg should look to read the template context.
-            extra_context: A set of template overrides that will supercede those found in the
-            "context_file" or those provided by answering the template questionnaire.
+                extra_context: A set of template overrides that will supercede those found in the
+                "context_file" or those provided by answering the template questionnaire.
 
         Raises:
             MergeConflictException: Thrown when an upgrade results in merge conflicts between the
-            template branch and the merge-target branch.
+                template branch and the merge-target branch.
             TemplateNotFoundException: When the repo does not already contain a template branch. If
-            you encounter this please run "battenberg install" instead.
+                you encounter this please run "battenberg install" instead.
         """
 
         if extra_context is None:

--- a/battenberg/core.py
+++ b/battenberg/core.py
@@ -101,8 +101,6 @@ class Battenberg:
             # Ensure we're merging into the right
             self.repo.checkout(merge_target_ref)
 
-            import pdb; pdb.set_trace()
-
             # Let's merge template changes using --allow-unrelated-histories. This will allow
             # the disjoint histories to be merged successfully. If you want to manually replicate
             # this option please run:
@@ -140,7 +138,7 @@ class Battenberg:
         else:
             raise BattenbergException(f'Unknown merge analysis result: {analysis}')
 
-    def install(self, template: str, checkout: str = 'master', extra_context: Dict = None,
+    def install(self, template: str, checkout: str = 'master',
                 no_input: bool = False):
         """Creates a fresh template install within the supplied repo.
 
@@ -153,8 +151,6 @@ class Battenberg:
                 the template repo.
             no_input: Whether to ask the user to answer the template questions again or take the
                 default answers from the templates "cookiecutter.json".
-            extra_context: A set of template overrides that will supercede those found in the
-                "context_file" or those provided by answering the template questionnaire.
 
         Raises:
             MergeConflictException: Thrown when an upgrade results in merge conflicts between the
@@ -162,9 +158,6 @@ class Battenberg:
             TemplateConflictException: When the repo already contains a template branch. If you
                 encounter this please run "battenberg upgrade" instead.
         """
-
-        if extra_context is None:
-            extra_context = {}
 
         # Assert template branch doesn't exist or raise conflict
         if self.is_installed():
@@ -175,8 +168,7 @@ class Battenberg:
             cookiecutter_kwargs = {
                 'template': template,
                 'checkout': checkout,
-                'no_input': no_input,
-                'extra_context': extra_context
+                'no_input': no_input
             }
             self._cookiecut(cookiecutter_kwargs, worktree)
 
@@ -207,7 +199,7 @@ class Battenberg:
         self._merge_template_branch(f'Installed template \'{template}\'')
 
     def upgrade(self, checkout: str = 'master', no_input: bool = True, merge_target: str = None,
-                context_file: str = '.cookiecutter.json', extra_context: Dict = None):
+                context_file: str = '.cookiecutter.json'):
         """Updates a repo using the found template context.
 
         Generates and applies any updates from the current repo state to the template state defined
@@ -222,8 +214,6 @@ class Battenberg:
             merge_target: A branch to checkout other than the current HEAD. Useful if you're
                 upgrading a project you do not directly own.
             context_file: Where battenberg should look to read the template context.
-                extra_context: A set of template overrides that will supercede those found in the
-                "context_file" or those provided by answering the template questionnaire.
 
         Raises:
             MergeConflictException: Thrown when an upgrade results in merge conflicts between the
@@ -231,9 +221,6 @@ class Battenberg:
             TemplateNotFoundException: When the repo does not already contain a template branch. If
                 you encounter this please run "battenberg install" instead.
         """
-
-        if extra_context is None:
-            extra_context = {}
 
         if not self.is_installed():
             try:
@@ -250,10 +237,6 @@ class Battenberg:
         template = context['_template']
         logger.debug(f'Found template: {template}')
 
-        # Merge original context and extra_context (priority to extra_context)
-        context.update(extra_context)
-        logger.debug(f'Context incl. extra: {context}')
-
         # Create temporary EMPTY worktree
         with TemporaryWorktree(self.repo, WORKTREE_NAME) as worktree:
             # Set HEAD to template branch
@@ -263,8 +246,7 @@ class Battenberg:
             cookiecutter_kwargs = {
                 'template': template,
                 'checkout': checkout,
-                'no_input': no_input,
-                'extra_context': context
+                'no_input': no_input
             }
             self._cookiecut(cookiecutter_kwargs, worktree)
 

--- a/battenberg/core.py
+++ b/battenberg/core.py
@@ -98,7 +98,6 @@ class Battenberg:
             logger.info('The branch is already up to date, no need to merge.')
 
         elif analysis & GIT_MERGE_ANALYSIS_FASTFORWARD or analysis & GIT_MERGE_ANALYSIS_NORMAL:
-
             # Ensure we're merging into the right
             self.repo.checkout(merge_target_ref)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from types import TracebackType
 from typing import List, Optional, Type
 import pytest
 from pygit2 import Repository, init_repository
+from battenberg.core import Battenberg
 
 
 class TemporaryRepository:
@@ -78,4 +79,11 @@ def template_repo() -> Repository:
     )
     repo.branches.local.create('upgrade', repo[upgrade_commit_id])
 
+    return repo
+
+
+@pytest.fixture
+def installed_repo(repo: Repository, template_repo: Repository) -> Repository:
+    battenberg = Battenberg(repo)
+    battenberg.install(template_repo.workdir, no_input=True)
     return repo

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,12 +1,80 @@
+from typing import Dict
+from unittest.mock import Mock, patch
 import pytest
 from click.testing import CliRunner
+from cookiecutter.exceptions import CookiecutterException
+from pygit2 import Repository
 from battenberg import cli
+from battenberg.errors import BattenbergException, MergeConflictException
 
 
-def test_cli():
+@pytest.fixture
+def open_repository(installed_repo: Repository) -> Mock:
+    with patch('battenberg.utils.open_repository') as open_repository:
+        open_repository.return_value = installed_repo
+        yield open_repository
+
+
+@pytest.fixture
+def Battenberg(open_repository: Mock) -> Mock:
+    with patch('battenberg.cli.Battenberg') as Battenberg:
+        yield Battenberg
+
+
+@pytest.fixture
+def obj() -> Dict:
+    return {'target': '.'}
+
+
+def test_help():
     runner = CliRunner()
     result = runner.invoke(cli.main)
     assert result.exit_code == 0
     help_result = runner.invoke(cli.main, ['--help'])
     assert help_result.exit_code == 0
     assert '--help' in help_result.output
+
+
+def test_install(Battenberg: Mock, obj: Dict):
+    template = 'test-template'
+
+    runner = CliRunner()
+    result = runner.invoke(cli.install, [template], obj=obj)
+
+    assert result.exit_code == 0
+    assert result.output == ''
+    Battenberg.return_value.install.assert_called_once_with(
+        template, checkout='master', no_input=False
+    )
+
+
+def test_upgrade(Battenberg: Mock, obj: Dict):
+    runner = CliRunner()
+    result = runner.invoke(cli.upgrade, obj=obj)
+
+    assert result.exit_code == 0
+    assert result.output == ''
+    Battenberg.return_value.upgrade.assert_called_once_with(
+        checkout='master',
+        context_file='.cookiecutter.json',
+        merge_target=None,
+        no_input=False
+    )
+
+
+def test_upgrade_raises_merge_conflicts(Battenberg: Mock, obj: Dict):
+    Battenberg.return_value.upgrade.side_effect = MergeConflictException
+    stdout = b'test-stdout'  # Use a bytestream as subprocess does.
+
+    with patch('battenberg.cli.subprocess') as subprocess:
+        completed_process = subprocess.run.return_value
+        completed_process.stdout = stdout
+
+        runner = CliRunner()
+        result = runner.invoke(cli.upgrade, obj=obj)
+
+        subprocess.run.assert_called_once_with(['git', 'status'], stdout=subprocess.PIPE,
+                                               stderr=subprocess.STDOUT)
+
+    assert result.exit_code == 1
+    assert stdout.decode('utf-8') in result.output

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,19 +5,12 @@ from battenberg.errors import TemplateConflictException, TemplateNotFoundExcepti
 from battenberg.core import Battenberg
 
 
-@pytest.fixture
-def installed_repo(repo: Repository, template_repo: Repository) -> Repository:
-    battenberg = Battenberg(repo)
-    battenberg.install(template_repo.workdir, no_input=True)
-    return repo
-
-
 def find_ref_from_message(repo: Repository, message: str, ref_name: str = 'master') -> Reference:
     return next(ref for ref in repo.references[f'refs/heads/{ref_name}'].log()
                 if ref.message == message)
 
 
-def test_install(repo, template_repo):
+def test_install(repo: Repository, template_repo: Repository):
     battenberg = Battenberg(repo)
     battenberg.install(template_repo.workdir, no_input=True)
 
@@ -38,7 +31,7 @@ def test_install(repo, template_repo):
     assert not template_oids - set(repo[master_merge_ref.oid_new].parent_ids)
 
 
-def test_install_raises_template_conflict(repo, template_repo):
+def test_install_raises_template_conflict(repo: Repository, template_repo: Repository):
     # Create an existing template branch to force the error.
     repo.create_branch('template', repo[repo.head.target])
 
@@ -48,14 +41,14 @@ def test_install_raises_template_conflict(repo, template_repo):
         battenberg.install(template_repo.workdir)
 
 
-def test_upgrade_raises_template_not_found(repo):
+def test_upgrade_raises_template_not_found(repo: Repository):
     repo.remotes.delete('origin')
     battenberg = Battenberg(repo)
     with pytest.raises(TemplateNotFoundException):
         battenberg.upgrade()
 
 
-def test_upgrade_fetches_remote_template(installed_repo, template_repo):
+def test_upgrade_fetches_remote_template(installed_repo: Repository, template_repo: Repository):
     # installed_repo.remotes.create('origin', 'git@github.com:zillow/battenberg.git')
     template_oid = installed_repo.references.get('refs/heads/template').target
     installed_repo.branches.remote.create('origin/template', installed_repo[template_oid])
@@ -71,7 +64,7 @@ def test_upgrade_fetches_remote_template(installed_repo, template_repo):
         get_mock.assert_called_once_with('refs/remotes/origin/template')
 
 
-def test_upgrade(installed_repo, template_repo):
+def test_upgrade(installed_repo: Repository, template_repo: Repository):
     battenberg = Battenberg(installed_repo)
     battenberg.upgrade(checkout='upgrade', no_input=True)
 
@@ -87,7 +80,7 @@ def test_upgrade(installed_repo, template_repo):
     assert template_oids & set(installed_repo[master_merge_ref.oid_new].parent_ids)
 
 
-def test_update_merge_target(installed_repo, template_repo):
+def test_update_merge_target(installed_repo: Repository, template_repo: Repository):
     merge_target = 'target'
     battenberg = Battenberg(installed_repo)
     battenberg.upgrade(checkout='upgrade', no_input=True, merge_target=merge_target)


### PR DESCRIPTION
To do:
- [x] Add in handling for `MergeConflictException` to nicely format the output of a merge conflict operation.
- [x] Extend CLI tests to cover this scenario.

Before:

```
 /tmp/pricing-triage   master  battenberg upgrade --checkout v2.0.0-alpha.2 --merge-target archetype-update-v2.0.0 --no-input
Removing example code starting
Removing example code complete
Traceback (most recent call last):
  File "/Users/alexla/Code/battenberg/battenberg/cli.py", line 104, in upgrade
    battenberg.upgrade(**kwargs)
  File "/Users/alexla/Code/battenberg/battenberg/core.py", line 291, in upgrade
    self._merge_template_branch(f'Upgraded template \'{template}\'', merge_target)
  File "/Users/alexla/Code/battenberg/battenberg/core.py", line 116, in _merge_template_branch
    f'Cannot merge the template commit ({branch.target}) with the current HEAD '
battenberg.errors.MergeConflictException: Cannot merge the template commit (45657f359bbb40747b38471953e1215b37d36d98) with the current HEAD (<_pygit2.Reference object at 0x106949f90>). Please resolve them manually and run 'git commit' to merge

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.6/bin/battenberg", line 11, in <module>
    load_entry_point('battenberg', 'console_scripts', 'battenberg')()
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/alexla/Code/battenberg/battenberg/cli.py", line 106, in upgrade
    raise click.ClickException from error
TypeError: __init__() missing 1 required positional argument: 'message'
```

After:

```
 /tmp/pricing-triage   master  battenberg upgrade --checkout v2.0.0-alpha.2 --merge-target archetype-update-v2.0.0 --no-input
Removing example code starting
Removing example code complete
ignoring NAME extension
On branch archetype-update-v2.0.0
You have unmerged paths.
  (fix conflicts and run "git commit")
  (use "git merge --abort" to abort the merge)

Changes to be committed:

	modified:   Dockerfile
	new file:   pricing_triage/variants/baseline/package.py

Unmerged paths:
  (use "git add/rm <file>..." as appropriate to mark resolution)

	both modified:   .cookiecutter.json
	both modified:   .gitlab-ci.yml
	both modified:   build.gradle
	both modified:   config/hyperparameters.json
	deleted by us:   dags/dag_pricing_triage.yaml
	added by us:     dags/dag_pricing_triage_gitlab.yaml
	both modified:   helm/values.yaml
	both added:      pricing_triage/variants/baseline/validation.py
	both deleted:    pricing_triage/variants/baseline_2/validation.py
	both modified:   versions.yaml

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	pricing_triage/variants/baseline/__init__.py~HEAD
	pricing_triage/variants/baseline/__init__.py~e5920091acd11311045210a05cdcf221bb4ff8c5
        ...


Cannot merge upgrade automatically, please manually resolve the conflicts
```