### PR TITLE
add max version for pygit2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     'cookiecutter>=1.6.0',
     # You'll also need to install libgit2 to get this to work.
     # See instructions here: https://www.pygit2.org/install.html
-    'pygit2>=0.28.0'
+    'pygit2>=0.28.0,<1.0'
 ]
 
 setup(


### PR DESCRIPTION
Currently (12Mar2020), most Mac OS X users who do a `brew install libgit2` will get version `0.28.x` yet when they then do a `pip install pygit2` they will get `1.1.x`. As per the `pygit2` [docs](https://www.pygit2.org/install.html#version-numbers), these are incompatible.

Now, this isn't a flaw with `battenberg` itself, because your docs clearly specify these two libraries as dependencies. But unless you specifically want people to build `libgit 1.x` from source and then install the corresponding `pygit2` version, it may increase adoption and improve user experience to just put an upper bound on the pygit version to prevent 1.x from getting installed and then complaining about an old libgit:

```
src/types.h:36:2: error: You need a compatible libgit2 version (0.99.x or 1.0.x)
  #error You need a compatible libgit2 version (0.99.x or 1.0.x)
```