### PR TITLE
Fix top level dir

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,9 +3,6 @@
 ## 0.2.3 (2020-05-19)
 
 - Refactor removal of top-level directory after cookiecutting to avoid collisions. (See [#15](https://github.com/zillow/battenberg/pull/15))
-
-## 0.x.x (YYYY-MM-DD)
-
 - Set upper limit on pygit2 dependency (See [#14](https://github.com/zillow/battenberg/pull/14))
 
 ## 0.2.2 (2020-01-29)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 0.2.3 (2020-05-19)
+
+- Refactor removal of top-level directory after cookiecutting to avoid collisions. (See [#15](https://github.com/zillow/battenberg/pull/15))
+
 ## 0.x.x (YYYY-MM-DD)
 
 - Set upper limit on pygit2 dependency (See [#14](https://github.com/zillow/battenberg/pull/14))

--- a/battenberg/cli.py
+++ b/battenberg/cli.py
@@ -1,14 +1,14 @@
 import os
 import sys
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))  # noqa: E402
-
-
 import logging
 import subprocess
 import click
+
 from battenberg.core import Battenberg
 from battenberg.utils import open_repository, open_or_init_repository
 from battenberg.errors import MergeConflictException
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))  # noqa: E402
 
 
 logger = logging.getLogger('battenberg')

--- a/tests/test_temporary_worktree.py
+++ b/tests/test_temporary_worktree.py
@@ -53,16 +53,16 @@ def test_raises_worktree_error(mkdtemp, repo, worktree_name, worktree_path):
 
 
 @pytest.mark.parametrize('empty,dir_contents', (
-    (True, ['.git']),
-    (False, ['.gitignore', '.git', 'hello.txt'])
+    (True, {'.git'}),
+    (False, {'.gitignore', '.git', 'hello.txt'})
 ))
 def test_initializes_empty_worktree(repo, worktree_name, empty, dir_contents):
     # Loop over all the entries in the unstaged tree.
-    get_tree_entries = lambda r: [entry.name for entry in r[r.head.target].tree]
-    assert get_tree_entries(repo) == ['.gitignore', 'hello.txt']
+    get_tree_entries = lambda r: {entry.name for entry in r[r.head.target].tree}
+    assert get_tree_entries(repo) == {'.gitignore', 'hello.txt'}
 
     with TemporaryWorktree(repo, worktree_name, empty=empty) as tmp_worktree:
         # Not an easy way to compare apples to apples here as it constructs the worktree
         # and immediately empties it in the same function. Some work todo here to make
         # this a little cleaner in the future I think.
-        assert sorted(os.listdir(tmp_worktree.path)) == sorted(dir_contents)
+        assert set(os.listdir(tmp_worktree.path)) == dir_contents

--- a/tests/test_temporary_worktree.py
+++ b/tests/test_temporary_worktree.py
@@ -65,4 +65,4 @@ def test_initializes_empty_worktree(repo, worktree_name, empty, dir_contents):
         # Not an easy way to compare apples to apples here as it constructs the worktree
         # and immediately empties it in the same function. Some work todo here to make
         # this a little cleaner in the future I think.
-        assert os.listdir(tmp_worktree.path) == dir_contents
+        assert sorted(os.listdir(tmp_worktree.path)) == sorted(dir_contents)


### PR DESCRIPTION
- When the cookiecutter project template directory name matches a
sub-directory name, battenberg will fail to install or upgrade to a
collision in shutil.move.
- Rather than moving the project files up a directory, use a separate
temporary directory as a staging ground for the cookiecutter output.
Then move the desired contents into the temporary worktree.