### PR TITLE
AIPO-949: Update pygit2 dependency to handle updated libgit2.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,8 @@
 # Release History
 
-## 0.3.0 (XXXX-XX-XX)
+## 0.3.0 (2020-05-29)
 
-- Update `pygit2` dependency to `>= 1.0`, can now rely on `libgit2 >= 1.0` too. (See [#17](https://github.com/zillow/battenberg/pull/17))
+- Update `pygit2` dependency to `>= 1.0`, can now rely on `libgit2 >= 1.0` too. (See [#18](https://github.com/zillow/battenberg/pull/18))
 - Add in better debug logging (See [#16](https://github.com/zillow/battenberg/pull/16))
 
 ## 0.2.3 (2020-05-19)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,9 @@
 # Release History
 
-## 0.2.XX (XXXX-XX-XX)
+## 0.3.0 (XXXX-XX-XX)
 
-- Add in better debug logging (See [#14](https://github.com/zillow/battenberg/pull/16))
+- Update `pygit2` dependency to `>= 1.0`, can now rely on `libgit2 >= 1.0` too. (See [#17](https://github.com/zillow/battenberg/pull/17))
+- Add in better debug logging (See [#16](https://github.com/zillow/battenberg/pull/16))
 
 ## 0.2.3 (2020-05-19)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip install battenberg
 ```
 
 If you're on Mac OS X or Windows please follow the [installation guides](https://www.pygit2.org/install.html#) in the `pygit2` documentation
-as well as `battenberg` relies on `libgit2` which needs to be installed first.
+as well as `battenberg` relies on `libgit2` which needs to be installed first. **Please install `libgit2 >= 1.0`.**
 
 ## Prerequistes
 

--- a/battenberg/__init__.py
+++ b/battenberg/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.2.3'
+__version__ = '0.3.0'
 
 
 from battenberg.core import Battenberg

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     'cookiecutter>=1.6.0',
     # You'll also need to install libgit2 to get this to work.
     # See instructions here: https://www.pygit2.org/install.html
-    'pygit2>=0.28.0,<1.0'
+    'pygit2>=1.0'
 ]
 
 setup(


### PR DESCRIPTION
Fixes the error if the user does not back-pin `libgit2` to `v0.28.x`, current Homebrew installs `v1.0.0` by default now. 

```
File "/Users/ashleybi/.pyenv/versions/3.6.8/lib/python3.6/site-packages/pygit2/remote.py", line 128, in fetch
    payload.check_error(err)
  File "/Users/ashleybi/.pyenv/versions/3.6.8/lib/python3.6/site-packages/pygit2/callbacks.py", line 93, in check_error
    check_error(error_code)
  File "/Users/ashleybi/.pyenv/versions/3.6.8/lib/python3.6/site-packages/pygit2/errors.py", line 65, in check_error
    raise GitError(message)
_pygit2.GitError: unsupported URL protocol
```