### PR TITLE
AIPO-999: Infer initial branch from existing remote HEAD

### DIFF
--- a/battenberg/cli.py
+++ b/battenberg/cli.py
@@ -77,7 +77,7 @@ def install(ctx, template: str, initial_branch: Optional[str], **kwargs):
     TEMPLATE is expected to be the URL of a git repository.
     """
 
-    battenberg = Battenberg(open_or_init_repository(ctx.obj['target'], initial_branch))
+    battenberg = Battenberg(open_or_init_repository(ctx.obj['target'], template, initial_head))
     battenberg.install(template, **kwargs)
 
 

--- a/battenberg/cli.py
+++ b/battenberg/cli.py
@@ -77,7 +77,7 @@ def install(ctx, template: str, initial_branch: Optional[str], **kwargs):
     TEMPLATE is expected to be the URL of a git repository.
     """
 
-    battenberg = Battenberg(open_or_init_repository(ctx.obj['target'], template, initial_head))
+    battenberg = Battenberg(open_or_init_repository(ctx.obj['target'], template, initial_branch))
     battenberg.install(template, **kwargs)
 
 

--- a/battenberg/cli.py
+++ b/battenberg/cli.py
@@ -59,7 +59,7 @@ def main(ctx, o: str, verbose: bool):
 @click.option(
     '--initial-branch',
     help='The initial branch name to use when creating a new repo',
-    default='main'
+    default=None
 )
 @click.option(
     '--checkout',

--- a/battenberg/utils.py
+++ b/battenberg/utils.py
@@ -42,6 +42,7 @@ def set_initial_branch(repo: Repository, template: str) -> Repository:
         ['git', 'ls-remote', '--symref', template, 'HEAD'],
         stdout=subprocess.PIPE, encoding='utf-8')
     found_refs = completed_process.stdout.split('\n')
+
     if found_refs:
         match = re.match(r"^ref: (?P<initial_branch>(\w+)/(\w+)/(\w+))\s*HEAD", found_refs[0])
         if match:

--- a/battenberg/utils.py
+++ b/battenberg/utils.py
@@ -51,7 +51,6 @@ def get_credentials(template: str) -> Union[Keypair, UserPass]:
 def set_initial_branch(repo: Repository, template: str) -> Repository:
     remote_name = 'template'
     try:
-        import pdb; pdb.set_trace()
         credentials = get_credentials(template)
     except ValueError as e:
         logger.debug(e)

--- a/battenberg/utils.py
+++ b/battenberg/utils.py
@@ -1,11 +1,9 @@
 import os
 import logging
 import re
-import getpass
 import subprocess
-from typing import Optional, Union
-from pygit2 import (discover_repository, init_repository, Keypair, RemoteCallbacks, Repository,
-                    UserPass)
+from typing import Optional
+from pygit2 import discover_repository, init_repository, Keypair, Repository
 
 
 logger = logging.getLogger(__name__)
@@ -39,24 +37,13 @@ def open_or_init_repository(path: str, template: str, initial_branch: Optional[s
     return repo
 
 
-def get_credentials(template: str) -> Union[Keypair, UserPass]:
-    if 'https' in template:
-        username = getpass.getuser()
-        password = getpass.getpass()
-        return UserPass(username, password)
-    elif 'git@' in template:
-        return construct_keypair()
-    else:
-        raise ValueError(f'Unsupported template URL type: {template}')
-
-
 def set_initial_branch(repo: Repository, template: str) -> Repository:
     completed_process = subprocess.run(
         ['git', 'ls-remote', '--symref', template, 'HEAD'],
         stdout=subprocess.PIPE, encoding='utf-8')
     found_refs = completed_process.stdout.split('\n')
     if found_refs:
-        match = re.match("^ref: (?P<initial_branch>(\w+)/(\w+)/(\w+))\s*HEAD", found_refs[0])
+        match = re.match(r"^ref: (?P<initial_branch>(\w+)/(\w+)/(\w+))\s*HEAD", found_refs[0])
         if match:
             initial_branch = match.group('initial_branch')
             logger.debug(f'Found remote default branch: {initial_branch}')

--- a/battenberg/utils.py
+++ b/battenberg/utils.py
@@ -1,13 +1,19 @@
 import os
-from typing import Optional
-from pygit2 import Repository, discover_repository, init_repository, Keypair
+import logging
+import getpass
+from typing import Optional, Union
+from pygit2 import (discover_repository, init_repository, Keypair, RemoteCallbacks, Repository,
+                    UserPass)
+
+
+logger = logging.getLogger(__name__)
 
 
 def open_repository(path: str) -> Repository:
     return Repository(discover_repository(path))
 
 
-def open_or_init_repository(path: str, initial_branch: Optional[str] = None):
+def open_or_init_repository(path: str, template: str, initial_branch: Optional[str] = None):
     try:
         return open_repository(path)
     except Exception:
@@ -15,6 +21,11 @@ def open_or_init_repository(path: str, initial_branch: Optional[str] = None):
         pass
 
     repo = init_repository(path, initial_head=initial_branch)
+
+    # Mirror the default HEAD of the template repo if client hasn't explicitly provided it.
+    if not initial_branch:
+        repo = set_initial_branch(repo, template)
+
     repo.create_commit(
         'HEAD',
         repo.default_signature,
@@ -23,6 +34,44 @@ def open_or_init_repository(path: str, initial_branch: Optional[str] = None):
         repo.index.write_tree(),
         []
     )
+    return repo
+
+
+def get_credentials(template: str) -> Union[Keypair, UserPass]:
+    if 'https' in template:
+        username = getpass.getuser()
+        password = getpass.getpass()
+        return UserPass(username, password)
+    elif 'git@' in template:
+        return construct_keypair()
+    else:
+        raise ValueError(f'Unsupported template URL type: {template}')
+
+
+def set_initial_branch(repo: Repository, template: str) -> Repository:
+    remote_name = 'template'
+    try:
+        import pdb; pdb.set_trace()
+        credentials = get_credentials(template)
+    except ValueError as e:
+        logger.debug(e)
+        return repo
+
+    repo.remotes.create(remote_name, template)
+    remotes = repo.remotes[remote_name].ls_remotes(
+        callbacks=RemoteCallbacks(credentials=credentials))
+    for remote in remotes:
+        if remote['name'] == 'HEAD':
+            # We found the remote HEAD, now set the found symbolic_ref (ie. the default branch
+            # name), as the default branch for the newly created repo.
+            default_branch_name = remote['symref_target'].split()[-1]
+
+            # TODO AIPO-999 Actually take the symref_target and create a new HEAD branch and
+            # rearrange references.
+            print('symref_target: ', remote['symref_target'], default_branch_name)
+            break
+    repo.remotes.delete(remote_name)
+
     return repo
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,7 +25,8 @@ def test_open_repository(Repository, discover_repository):
 
 def test_open_or_init_repository_opens_repo(Repository, discover_repository):
     path = 'test-path'
-    assert open_or_init_repository(path) == Repository.return_value
+    template = 'test-template'
+    assert open_or_init_repository(path, template) == Repository.return_value
     Repository.assert_called_once_with(discover_repository.return_value)
     discover_repository.assert_called_once_with(path)
 
@@ -35,9 +36,10 @@ def test_open_or_init_repository_initializes_repo(init_repository, Repository, d
     discover_repository.side_effect = Exception('No repo found')
 
     path = 'test-path'
+    template = 'test-template'
     initial_branch = 'test-initial_branch'
     repo = init_repository.return_value
-    assert open_or_init_repository(path, initial_branch) == repo
+    assert open_or_init_repository(path, template, initial_branch) == repo
     init_repository.assert_called_once_with(path, initial_head=initial_branch)
     init_repository.return_value.create_commit.assert_called_once_with(
         'HEAD',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,29 +1,41 @@
 import os
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 import pytest
 from battenberg.utils import open_repository, open_or_init_repository, construct_keypair
 
 
 @pytest.fixture
-def Repository():
+def Repository() -> Mock:
     with patch('battenberg.utils.Repository') as Repository:
         yield Repository
 
 
 @pytest.fixture
-def discover_repository():
+def discover_repository() -> Mock:
     with patch('battenberg.utils.discover_repository') as discover_repository:
         yield discover_repository
 
 
-def test_open_repository(Repository, discover_repository):
+@pytest.fixture
+def init_repository() -> Mock:
+    with patch('battenberg.utils.init_repository') as init_repository:
+        yield init_repository
+
+
+@pytest.fixture
+def Keypair() -> Mock:
+    with patch('battenberg.utils.Keypair') as Keypair:
+        yield Keypair
+
+
+def test_open_repository(Repository: Mock, discover_repository: Mock):
     path = 'test-path'
     assert open_repository(path) == Repository.return_value
     Repository.assert_called_once_with(discover_repository.return_value)
     discover_repository.assert_called_once_with(path)
 
 
-def test_open_or_init_repository_opens_repo(Repository, discover_repository):
+def test_open_or_init_repository_opens_repo(Repository: Mock, discover_repository: Mock):
     path = 'test-path'
     template = 'test-template'
     assert open_or_init_repository(path, template) == Repository.return_value
@@ -31,8 +43,8 @@ def test_open_or_init_repository_opens_repo(Repository, discover_repository):
     discover_repository.assert_called_once_with(path)
 
 
-@patch('battenberg.utils.init_repository')
-def test_open_or_init_repository_initializes_repo(init_repository, Repository, discover_repository):
+def test_open_or_init_repository_initializes_repo(init_repository: Mock, Repository: Mock,
+        discover_repository: Mock):
     discover_repository.side_effect = Exception('No repo found')
 
     path = 'test-path'
@@ -51,16 +63,41 @@ def test_open_or_init_repository_initializes_repo(init_repository, Repository, d
     )
 
 
-@patch('battenberg.utils.Keypair')
-def test_construct_keypair_defaults(Keypair):
+@patch('battenberg.utils.subprocess')
+def test_open_or_init_repository_initializes_repo_with_inferred_initial_branch(subprocess: Mock,
+        init_repository: Mock, Repository: Mock, discover_repository: Mock):
+    initial_branch = 'refs/heads/main'
+    subprocess.run.return_value.stdout = f'ref: {initial_branch}    HEAD'
+    discover_repository.side_effect = Exception('No repo found')
+
+    path = 'test-path'
+    template = 'test-template'
+    repo = init_repository.return_value
+    assert open_or_init_repository(path, template) == repo
+    repo.references['HEAD'].set_target.assert_called_once_with(initial_branch)
+
+
+@pytest.mark.parametrize('stdout', ('', 'invalid-symref'))
+@patch('battenberg.utils.subprocess')
+def test_open_or_init_repository_initializes_repo_with_invalid_remote_branches(subprocess: Mock,
+        init_repository: Mock, Repository: Mock, discover_repository: Mock, stdout: str):
+    subprocess.run.return_value.stdout = stdout
+    discover_repository.side_effect = Exception('No repo found')
+
+    path = 'test-path'
+    template = 'test-template'
+    repo = init_repository.return_value
+    assert open_or_init_repository(path, template) == repo
+
+
+def test_construct_keypair_defaults(Keypair: Mock):
     construct_keypair()
     user_home = os.path.expanduser('~')
     Keypair.assert_called_once_with('git', f'{user_home}/.ssh/id_rsa.pub',
                                     f'{user_home}/.ssh/id_rsa', '')
 
 
-@patch('battenberg.utils.Keypair')
-def test_construct_keypair(Keypair):
+def test_construct_keypair(Keypair: Mock):
     public_key_path = 'test-public_key_path'
     private_key_path = 'test-private_key_path'
     passphrase = 'test-passphrase'


### PR DESCRIPTION
Switch to use `git ls-remote --symref` via the `git` CLI to avoid dependency hell with `libgit2`. Use the found `default_branch` naming to update the `HEAD` target reference, as there are no commits in the new repo by that point the symbolic reference can be updated without consequences, then when the [first commit is created](https://github.com/zillow/battenberg/pull/22/files#diff-e36bae9b2c06ea15dbfa5960076158e0a2fa4791a834ebd08ad2a23d1cc10125R31) as that uses `HEAD` it'll automatically pick up the change!