### PR TITLE
AIPO-1008: Reformat error messages from user validation nicer.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.4.1 (2021-01-XX)
+## 0.4.1 (2021-01-25)
 
 - Suppress stacktrace logging when hook exits unsuccessfully (See [#23](https://github.com/zillow/battenberg/pull/23))
 - Ensure we're compatible with updated `Repository.__init__` constructor (See [#23](https://github.com/zillow/battenberg/pull/23))

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 0.4.1 (2021-01-XX)
+
+- Suppress stacktrace logging when hook exits unsuccessfully (See [#23](https://github.com/zillow/battenberg/pull/23))
+- Ensure we're compatible with updated `Repository.__init__` constructor (See [#23](https://github.com/zillow/battenberg/pull/23))
+
 ## 0.4.0 (2020-10-13)
 
 - Remove `master` as the default `git` target branch terminology to promote equity and belonging. Instead rely on remote HEAD to infer default branch naming convention.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install battenberg
 If you're on Mac OS X or Windows please follow the [installation guides](https://www.pygit2.org/install.html#) in the `pygit2` documentation
 as well as `battenberg` relies on `libgit2` which needs to be installed first. **Please install `libgit2 >= 1.0`.**
 
-If you use SSH to connect to `git`, please also install OpenSSL **prior to installing `libgit2`!!** Most like you can do this via `brew install openssl`
+If you use SSH to connect to `git`, please also install `libssh2` **prior to installing `libgit2`!!** Most like you can do this via `brew install libssh2`
 if you are on Mac OS X.
 
 ## Prerequistes
@@ -129,6 +129,37 @@ git push origin <version>
 Then watch Travis CI build for any errors, eventually it should appear on the [`battenberg` PyPI](https://pypi.org/project/battenberg/) project.
 
 ## FAQ
+
+* I got an error like `_pygit2.GitError: unsupported URL protocol`, how do I fix this?
+
+    Likely you're using a `git` URL with `ssh` and have installed `pygit2` without access to the underlying `libssh2`
+    library. To test this run:
+
+    ```bash
+    $ python -c "import pygit2; print(bool(pygit2.features & pygit2.GIT_FEATURE_SSH))"
+    False
+    ```
+
+    To remedy this run:
+
+    ```bash
+    $ pip uninstall pygit2
+    ...
+    # Hopefully you have this, but this will install the compiler toolchain for OS X.
+    $ xcode-select --install
+    ...
+    $ brew install libssh2
+    ...
+    $ brew install libgit2
+    ...
+    # The python wheels for Mac OS X for pygit2 are not built with SSH support by default so tell pip
+    # to install pygit2 from source.
+    $ pip install pygit2 --no-binary pygit2
+    ...
+    # Finally test out to ensure pygit2 picks up the SSH features.
+    $ python -c "import pygit2; print(bool(pygit2.features & pygit2.GIT_FEATURE_SSH))"
+    True
+    ```
 
 * Why are you using a new `.cookiecutter.json` pattern instead of using the [`replay` pattern](https://cookiecutter.readthedocs.io/en/latest/advanced/replay.html)?
 

--- a/battenberg/__init__.py
+++ b/battenberg/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.0'
+__version__ = '0.5.0'
 
 
 from battenberg.core import Battenberg

--- a/battenberg/__init__.py
+++ b/battenberg/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.5.0'
+__version__ = '0.4.1'
 
 
 from battenberg.core import Battenberg

--- a/battenberg/core.py
+++ b/battenberg/core.py
@@ -64,6 +64,7 @@ class Battenberg:
                     **cookiecutter_kwargs
                 )
             except FailedHookException as e:
+                raise
                 # Suppress stacktrace for known hook error to ensure it is easy for user to diget.
                 logging.error(e)
                 sys.exit(1)

--- a/battenberg/core.py
+++ b/battenberg/core.py
@@ -64,7 +64,6 @@ class Battenberg:
                     **cookiecutter_kwargs
                 )
             except FailedHookException as e:
-                raise
                 # Suppress stacktrace for known hook error to ensure it is easy for user to diget.
                 logging.error(e)
                 sys.exit(1)

--- a/battenberg/errors.py
+++ b/battenberg/errors.py
@@ -57,3 +57,12 @@ class MergeConflictException(BattenbergException):
     Error raised when we cannot merge the template commit with the target branch.
     """
     pass
+
+
+class InvalidRepositoryException(BattenbergException):
+    """
+    Error raised when Git repository is invalid.
+    """
+
+    def __init__(self, path: str):
+        super().__init__(f'{path} is not a valid repository path.')

--- a/battenberg/utils.py
+++ b/battenberg/utils.py
@@ -14,6 +14,8 @@ def open_repository(path: str) -> Repository:
     try:
         repo_path = discover_repository(path)
     except Exception as e:
+        # Looks like exceptions raised in the C code from pygit2 are all of type Exception so
+        # we're forced to rely on the message to interpret.
         if 'No repo found' in str(e):
             raise InvalidRepositoryException(path)
         raise

--- a/battenberg/utils.py
+++ b/battenberg/utils.py
@@ -13,7 +13,7 @@ def open_repository(path: str) -> Repository:
     repo_path = discover_repository(path)
     if repo_path:
         return Repository(repo_path)
-    
+
     raise ValueError(f'{path} is not a valid repository path.')
 
 

--- a/battenberg/utils.py
+++ b/battenberg/utils.py
@@ -4,23 +4,30 @@ import re
 import subprocess
 from typing import Optional
 from pygit2 import discover_repository, init_repository, Keypair, Repository
+from battenberg.errors import InvalidRepositoryException
 
 
 logger = logging.getLogger(__name__)
 
 
 def open_repository(path: str) -> Repository:
-    repo_path = discover_repository(path)
-    if repo_path:
-        return Repository(repo_path)
+    try:
+        repo_path = discover_repository(path)
+    except Exception as e:
+        if 'No repo found' in str(e):
+            raise InvalidRepositoryException(path)
+        raise
 
-    raise ValueError(f'{path} is not a valid repository path.')
+    if not repo_path:
+        raise InvalidRepositoryException(path)
+
+    return Repository(repo_path)
 
 
 def open_or_init_repository(path: str, template: str, initial_branch: Optional[str] = None):
     try:
         return open_repository(path)
-    except Exception:
+    except InvalidRepositoryException:
         # Not found any repo, let's make one.
         pass
 

--- a/battenberg/utils.py
+++ b/battenberg/utils.py
@@ -10,7 +10,11 @@ logger = logging.getLogger(__name__)
 
 
 def open_repository(path: str) -> Repository:
-    return Repository(discover_repository(path))
+    repo_path = discover_repository(path)
+    if repo_path:
+        return Repository(repo_path)
+    
+    raise ValueError(f'{path} is not a valid repository path.')
 
 
 def open_or_init_repository(path: str, template: str, initial_branch: Optional[str] = None):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,7 @@
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 import pytest
 from pygit2 import Reference, Repository
+from cookiecutter.exceptions import FailedHookException
 from battenberg.errors import TemplateConflictException, TemplateNotFoundException
 from battenberg.core import Battenberg
 
@@ -39,6 +40,18 @@ def test_install_raises_template_conflict(repo: Repository, template_repo: Repos
 
     with pytest.raises(TemplateConflictException):
         battenberg.install(template_repo.workdir)
+
+
+@patch('battenberg.core.cookiecutter')
+def test_install_raises_failed_hook(cookiecutter: Mock, repo: Repository, template_repo: Repository):
+    cookiecutter.side_effect = FailedHookException
+
+    battenberg = Battenberg(repo)
+
+    with pytest.raises(SystemExit) as e:
+        battenberg.install(template_repo.workdir)
+
+    assert e.value.code == 1
 
 
 def test_upgrade_raises_template_not_found(repo: Repository):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import os
 from unittest.mock import Mock, patch
 import pytest
+from battenberg.errors import InvalidRepositoryException
 from battenberg.utils import open_repository, open_or_init_repository, construct_keypair
 
 
@@ -41,6 +42,14 @@ def test_open_repository(Repository: Mock, discover_repository: Mock):
     assert open_repository(path) == Repository.return_value
     Repository.assert_called_once_with(discover_repository.return_value)
     discover_repository.assert_called_once_with(path)
+
+
+def test_open_repository_raises_on_invalid_path():
+    path = 'test-path'
+    with pytest.raises(InvalidRepositoryException) as e:
+        open_repository(path)
+
+    assert str(e.value) == f'{path} is not a valid repository path.'
 
 
 def test_open_or_init_repository_opens_repo(Repository: Mock, discover_repository: Mock):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,6 +28,14 @@ def Keypair() -> Mock:
         yield Keypair
 
 
+def test_open_repository():
+    path = 'test-path'
+    with pytest.assertRaises(ValueError) as e:
+        open_repository(path)
+
+    assert str(e.value) == f'{path} is not a valid repository path.'
+
+
 def test_open_repository(Repository: Mock, discover_repository: Mock):
     path = 'test-path'
     assert open_repository(path) == Repository.return_value


### PR DESCRIPTION
To do:
- [x] Reformat error messages from user validation nicer.
    - Ensure the user can read the logging from the hook scripts by suppressing the stacktrace, doesn't add sufficient value in this error scenario and contributes to poor UX.
- [x] Ensure we can init a new repo via `battenberg install`. Looks like `pygit2` changed the interface of the `Repository.__init_` interface without marking the version as breaking 🤦 . See https://github.com/libgit2/pygit2/pull/1044/files
- [x] Add in FAQ item for common `_pygit2.GitError: unsupported URL protocol error`
- [x] Finalize release date in `HISTORY.md`

See this in action on [this PR](https://gitlab.zgtools.net/zillow-offers/zoml/ml-infrastructure/archetype.py-ml/-/merge_requests/170)