### PR TITLE
Update python versioning and fix poetry bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 matrix:
   include:
-  - name: Python 3.6
-    python: 3.6
   - name: Python 3.7
     python: 3.7
   - name: Python 3.8

--- a/battenberg/__init__.py
+++ b/battenberg/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.1'
+__version__ = '0.5.0'
 
 
 from battenberg.core import Battenberg

--- a/setup.py
+++ b/setup.py
@@ -55,11 +55,10 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8'
     ],
-    python_requires=">=3.6*",
+    python_requires=">=3.7",
     extras_require={
         'dev': ['pytest', 'pytest-cov', 'flake8', 'codecov']
     }


### PR DESCRIPTION
Removes version support in metadata for python3.6 which is EOL. Also fixes an issue with poetry compatibility described below.

It seems that battenberg may be causing issues in newer versions of poetry. I have `battenberg = "^0.4.1"` in my `pyproject.toml` file under `[tool.poetry.dependencies]`. I checked that this is the latest version released on pypi, which it appears to be. When I run `poetry install` in my project I get an error -

```
Installing dependencies from lock file

Could not parse version constraint: >=3.6*
```

Checking my poetry lock file the only place I see this version constraint used is

```toml
[[package]]
name = "battenberg"
version = "0.4.1"
description = "Providing updates to cookiecutter projects."
category = "main"
optional = false
python-versions = ">=3.6*"
```

I believe [this is the offending line in `setup.py`](https://github.com/zillow/battenberg/blob/main/setup.py#L62). I'm not sure exactly when poetry changed versioning constraints, but it appears that the splat operator is no longer allowed.

Thanks,
Anton