### PR TITLE
Remove ref to deprecated attribute on object (PyGit2). Commit.hex

### DIFF
--- a/battenberg/core.py
+++ b/battenberg/core.py
@@ -276,7 +276,7 @@ class Battenberg:
             commit = worktree.repo.get(oid)
 
         # Make template branch ref to created commit
-        self.repo.lookup_branch(TEMPLATE_BRANCH).set_target(commit.hex)
+        self.repo.lookup_branch(TEMPLATE_BRANCH).set_target(str(commit.id))
 
         # Let's merge our changes into HEAD
         self._merge_template_branch(

--- a/battenberg/core.py
+++ b/battenberg/core.py
@@ -275,7 +275,7 @@ class Battenberg:
             )
             commit = worktree.repo.get(oid)
 
-        # Make template branch ref to created commit
+        # Make template branch ref to created commit, see https://github.com/libgit2/pygit2/blob/master/CHANGELOG.md#1150-2024-05-18
         self.repo.lookup_branch(TEMPLATE_BRANCH).set_target(str(commit.id))
 
         # Let's merge our changes into HEAD


### PR DESCRIPTION
Running the upgrade, I found the tool to be broken and threw the following error
```
battenberg upgrade --no-input
Traceback (most recent call last):
  File "/Users/arpits/.pyenv/versions/3.11.9/bin/battenberg", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/arpits/.pyenv/versions/3.11.9/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/arpits/.pyenv/versions/3.11.9/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/arpits/.pyenv/versions/3.11.9/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/arpits/.pyenv/versions/3.11.9/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/arpits/.pyenv/versions/3.11.9/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/arpits/.pyenv/versions/3.11.9/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/arpits/.pyenv/versions/3.11.9/lib/python3.11/site-packages/battenberg/cli.py", line 112, in upgrade
    battenberg.upgrade(**kwargs)
  File "/Users/arpits/.pyenv/versions/3.11.9/lib/python3.11/site-packages/battenberg/core.py", line 279, in upgrade
    self.repo.lookup_branch(TEMPLATE_BRANCH).set_target(commit.hex)
                                                        ^^^^^^^^^^
AttributeError: '_pygit2.Commit' object has no attribute 'hex'
```
Debugging further noticed and realized that the attribute was deprecated in pygit2.

Reference to Change log for Pygit2: [Changelog](https://github.com/libgit2/pygit2/blob/master/CHANGELOG.md#1150-2024-05-18)

Specifically, it mentioned the following breaking change:
```
Remove deprecated object.hex, use str(object.id)
```

In order to fix that, I am creating this PR. If nothing else, I wanted to bring this to light when more people might run into this in future.