### PR TITLE
release 0.5.2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 0.5.2 (2024-11-12)
+
+- Update to pygit2 usage to enable usage of newer versions of the package while also maintaining backwards compatibility.
+
 ## 0.5.1 (2023-08-08)
 
 - Update python version to 3.9+

--- a/battenberg/__init__.py
+++ b/battenberg/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.5.1'
+__version__ = '0.5.2'
 
 
 from battenberg.core import Battenberg


### PR DESCRIPTION
Updates the history doc and pushes the versions as a bugfix/patch release in order to release an update to improve pygit2 compatibility. See [this PR](https://github.com/zillow/battenberg/pull/38) for those changes.