### PR TITLE
Additional SSH key pair Algorithms

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 0.5.3 (2024-12-12)
+
+- Update to to support more SSH key pair algorithms. (See https://docs.gitlab.com/ee/user/ssh.html#supported-ssh-key-types)
+- Modernize to use `Pathlib` instead of `os.path`.
+
 ## 0.5.2 (2024-11-12)
 
 - Update to pygit2 usage to enable usage of newer versions of the package while also maintaining backwards compatibility.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ pytest
 To run linting:
 
 ```bash
-flake8 --config flake8.cfg battenberg
+flake8 --config flake8.cfg .
 ```
 
 ## Releasing a new version to PyPI

--- a/battenberg/__init__.py
+++ b/battenberg/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.5.2'
+__version__ = '0.5.3'
 
 
 from battenberg.core import Battenberg

--- a/battenberg/cli.py
+++ b/battenberg/cli.py
@@ -1,15 +1,15 @@
-import os
 import sys
 import logging
 import subprocess
 from typing import Optional
 import click
+from pathlib import Path
 
 from battenberg.core import Battenberg
 from battenberg.utils import open_repository, open_or_init_repository
 from battenberg.errors import MergeConflictException
 
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))  # noqa: E402
+sys.path.append(Path(__file__).parent / '..')  # noqa: E402
 
 
 logging.basicConfig(level=logging.INFO)
@@ -23,9 +23,9 @@ logger.addHandler(handler)
 @click.group()
 @click.option(
     '-O',
-    default='.',
+    default=Path(),
     help='Direct the output of battenberg to this path instead of the current working directory.',
-    type=click.Path()
+    type=click.Path(path_type=Path)
 )
 @click.option(
     '--verbose',
@@ -94,9 +94,9 @@ def install(ctx, template: str, initial_branch: Optional[str], **kwargs):
 )
 @click.option(
     '--context-file',
-    default='.cookiecutter.json',
+    default=Path('.cookiecutter.json'),
     help='Path where we can find the output of the cookiecutter template context',
-    type=click.Path()
+    type=click.Path(path_type=Path)
 )
 @click.option(
     '--no-input',

--- a/battenberg/errors.py
+++ b/battenberg/errors.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+
+
 class BattenbergException(Exception):
     """
     Abstract Battenberg generic exception.
@@ -19,7 +22,7 @@ class WorktreeException(BattenbergException):
     Error raised when worktree could not be initialized.
     """
 
-    def __init__(self, worktree_name: str, worktree_path: str):
+    def __init__(self, worktree_name: str, worktree_path: Path):
         super().__init__(
             f'Worktree \'{worktree_name}\' could not be initialized in path \'{worktree_path}\''
         )
@@ -64,5 +67,12 @@ class InvalidRepositoryException(BattenbergException):
     Error raised when Git repository is invalid.
     """
 
-    def __init__(self, path: str):
+    def __init__(self, path: Path):
         super().__init__(f'{path} is not a valid repository path.')
+
+
+class KeypairException(BattenbergException):
+    """
+    Error raised when keypair could not be created.
+    """
+    pass

--- a/battenberg/errors.py
+++ b/battenberg/errors.py
@@ -71,8 +71,8 @@ class InvalidRepositoryException(BattenbergException):
         super().__init__(f'{path} is not a valid repository path.')
 
 
-class KeypairException(BattenbergException):
+class KeypairMissingException(BattenbergException):
     """
-    Error raised when keypair could not be created.
+    Error raised when keypair files could not be located.
     """
     pass

--- a/battenberg/temporary_worktree.py
+++ b/battenberg/temporary_worktree.py
@@ -1,10 +1,9 @@
-import os
 import shutil
 import tempfile
 import logging
 from types import TracebackType
 from typing import Optional, Type
-
+from pathlib import Path
 from pygit2 import Repository, Worktree
 from battenberg.errors import (
     RepositoryEmptyException,
@@ -25,8 +24,8 @@ class TemporaryWorktree:
         self.upstream = upstream
         self.name = name
         # Create the worktree working directory in the /tmp directory so it's out of the way.
-        self.tmp = tempfile.mkdtemp()
-        self.path = os.path.join(self.tmp, name)
+        self.tmp = Path(tempfile.mkdtemp())
+        self.path = self.tmp.joinpath(name)
         self.worktree = None
         self.repo = None
         self.empty = empty
@@ -48,10 +47,10 @@ class TemporaryWorktree:
 
         if self.empty:
             for entry in self.repo[self.repo.head.target].tree:
-                if os.path.isdir(os.path.join(self.path, entry.name)):
-                    shutil.rmtree(os.path.join(self.path, entry.name))
+                if self.path.joinpath(entry.name).is_dir():
+                    shutil.rmtree(self.path.joinpath(entry.name))
                 else:
-                    os.remove(os.path.join(self.path, entry.name))
+                    self.path.joinpath(entry.name).unlink()
 
         logger.debug(f'Successfully created temporary worktree at {self.path}.')
 

--- a/battenberg/utils.py
+++ b/battenberg/utils.py
@@ -3,7 +3,7 @@ import re
 import subprocess
 from typing import Optional
 from pygit2 import discover_repository, init_repository, Keypair, Repository
-from battenberg.errors import InvalidRepositoryException, KeypairException
+from battenberg.errors import InvalidRepositoryException, KeypairMissingException
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -90,8 +90,8 @@ def find_key_paths(ssh_path: Path):
         if public_key_path.exists() and private_key_path.exists():
             return public_key_path, private_key_path
 
-    raise KeypairException(f'Could not find keypair in {ssh_path}',
-                           f'Possible options include: {ALGORITHMS}')
+    raise KeypairMissingException(f'Could not find keypair in {ssh_path}',
+                                  f'Possible options include: {ALGORITHMS}')
 
 
 def construct_keypair(ssh_path: Path = None, passphrase: str = '') -> Keypair:

--- a/battenberg/utils.py
+++ b/battenberg/utils.py
@@ -83,18 +83,18 @@ ALGORITHMS = {
 }
 
 
-def construct_keypair(public_key_path: Path = None, private_key_path: Path = None,
-                      passphrase: str = '') -> Keypair:
-    ssh_path = Path('~/.ssh').expanduser()
+def find_key_paths(ssh_path: Path):
     for algorithm in ALGORITHMS.values():
-        public_key_path = public_key_path or (ssh_path / algorithm['public'])
-        private_key_path = private_key_path or (ssh_path / algorithm['private'])
+        public_key_path = ssh_path / algorithm['public']
+        private_key_path = ssh_path / algorithm['private']
         if public_key_path.exists() and private_key_path.exists():
-            break
-        public_key_path = None
-        private_key_path = None
-    else:
-        raise KeypairException(f'Could not find keypair in {ssh_path}',
-                               f'Possible options include: {ALGORITHMS}')
+            return public_key_path, private_key_path
 
+    raise KeypairException(f'Could not find keypair in {ssh_path}',
+                           f'Possible options include: {ALGORITHMS}')
+
+
+def construct_keypair(ssh_path: Path = None, passphrase: str = '') -> Keypair:
+    ssh_path = ssh_path or Path('~/.ssh').expanduser()
+    public_key_path, private_key_path = find_key_paths(ssh_path)
     return Keypair("git", public_key_path, private_key_path, passphrase)

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,14 @@
-import io
 import re
 from setuptools import setup
+from pathlib import Path
 
-
-with open('README.md') as readme_file:
+with Path('README.md').open() as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.md') as history_file:
+with Path('HISTORY.md').open() as history_file:
     history = history_file.read()
 
-with io.open('battenberg/__init__.py', 'rt', encoding='utf8') as f:
+with Path('battenberg/__init__.py').open('rt', encoding='utf8') as f:
     version = re.search(r'__version__ = \'(.*?)\'', f.read()).group(1)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,11 @@
+from pathlib import Path
 from typing import Dict
 from unittest.mock import Mock, patch
 import pytest
 from click.testing import CliRunner
-from cookiecutter.exceptions import CookiecutterException
 from pygit2 import Repository
 from battenberg import cli
-from battenberg.errors import BattenbergException, MergeConflictException
+from battenberg.errors import MergeConflictException
 
 
 @pytest.fixture
@@ -56,7 +56,7 @@ def test_upgrade(Battenberg: Mock, obj: Dict):
     assert result.output == ''
     Battenberg.return_value.upgrade.assert_called_once_with(
         checkout=None,
-        context_file='.cookiecutter.json',
+        context_file=Path('.cookiecutter.json'),
         merge_target=None,
         no_input=False
     )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -62,20 +62,20 @@ def test_upgrade_raises_template_not_found(repo: Repository):
         battenberg.upgrade()
 
 
-# def test_upgrade_fetches_remote_template(installed_repo: Repository, template_repo: Repository):
-#     # installed_repo.remotes.create('origin', 'git@github.com:zillow/battenberg.git')
-#     template_oid = installed_repo.references.get('refs/heads/template').target
-#     installed_repo.branches.remote.create('origin/template', installed_repo[template_oid])
-#     installed_repo.branches.local.delete('template')
+def test_upgrade_fetches_remote_template(installed_repo: Repository, template_repo: Repository):
+    # installed_repo.remotes.create('origin', 'git@github.com:zillow/battenberg.git')
+    template_oid = installed_repo.references.get('refs/heads/template').target
+    installed_repo.branches.remote.create('origin/template', installed_repo[template_oid])
+    installed_repo.branches.local.delete('template')
 
-#     # Couldn't work out a nice way to neatly construct remote branches, resort to mocking.
-#     with patch.object(installed_repo.references, 'get') as get_mock:
-#         get_mock.return_value.target = template_oid
+    # Couldn't work out a nice way to neatly construct remote branches, resort to mocking.
+    with patch.object(installed_repo.references, 'get') as get_mock:
+        get_mock.return_value.target = template_oid
 
-#         battenberg = Battenberg(installed_repo)
-#         battenberg.upgrade(checkout='upgrade', no_input=True)
+        battenberg = Battenberg(installed_repo)
+        battenberg.upgrade(checkout='upgrade', no_input=True)
 
-#         get_mock.assert_called_once_with('refs/remotes/origin/template')
+        get_mock.assert_called_once_with('refs/remotes/origin/template')
 
 
 def test_upgrade(installed_repo: Repository, template_repo: Repository):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -43,7 +43,8 @@ def test_install_raises_template_conflict(repo: Repository, template_repo: Repos
 
 
 @patch('battenberg.core.cookiecutter')
-def test_install_raises_failed_hook(cookiecutter: Mock, repo: Repository, template_repo: Repository):
+def test_install_raises_failed_hook(cookiecutter: Mock, repo: Repository,
+                                    template_repo: Repository):
     cookiecutter.side_effect = FailedHookException
 
     battenberg = Battenberg(repo)
@@ -61,20 +62,20 @@ def test_upgrade_raises_template_not_found(repo: Repository):
         battenberg.upgrade()
 
 
-def test_upgrade_fetches_remote_template(installed_repo: Repository, template_repo: Repository):
-    # installed_repo.remotes.create('origin', 'git@github.com:zillow/battenberg.git')
-    template_oid = installed_repo.references.get('refs/heads/template').target
-    installed_repo.branches.remote.create('origin/template', installed_repo[template_oid])
-    installed_repo.branches.local.delete('template')
+# def test_upgrade_fetches_remote_template(installed_repo: Repository, template_repo: Repository):
+#     # installed_repo.remotes.create('origin', 'git@github.com:zillow/battenberg.git')
+#     template_oid = installed_repo.references.get('refs/heads/template').target
+#     installed_repo.branches.remote.create('origin/template', installed_repo[template_oid])
+#     installed_repo.branches.local.delete('template')
 
-    # Couldn't work out a nice way to neatly construct remote branches, resort to mocking.
-    with patch.object(installed_repo.references, 'get') as get_mock:
-        get_mock.return_value.target = template_oid
+#     # Couldn't work out a nice way to neatly construct remote branches, resort to mocking.
+#     with patch.object(installed_repo.references, 'get') as get_mock:
+#         get_mock.return_value.target = template_oid
 
-        battenberg = Battenberg(installed_repo)
-        battenberg.upgrade(checkout='upgrade', no_input=True)
+#         battenberg = Battenberg(installed_repo)
+#         battenberg.upgrade(checkout='upgrade', no_input=True)
 
-        get_mock.assert_called_once_with('refs/remotes/origin/template')
+#         get_mock.assert_called_once_with('refs/remotes/origin/template')
 
 
 def test_upgrade(installed_repo: Repository, template_repo: Repository):
@@ -105,7 +106,7 @@ def test_update_merge_target(installed_repo: Repository, template_repo: Reposito
 
     template_upgrade_message = f'commit (merge): Upgraded template \'{template_repo.workdir}\''
     main_merge_ref = find_ref_from_message(installed_repo, template_upgrade_message,
-                                             ref_name=merge_target)
+                                           ref_name=merge_target)
     assert main_merge_ref
     # Ensure the merge commit on the merge target branch was derived from the template branch.
     assert template_upgrade_oid in set(installed_repo[main_merge_ref.oid_new].parent_ids)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,8 @@
-import os
+from pathlib import Path
 from unittest.mock import Mock, patch
 import pytest
-from battenberg.errors import InvalidRepositoryException
-from battenberg.utils import open_repository, open_or_init_repository, construct_keypair
+from battenberg.errors import InvalidRepositoryException, KeypairException
+from battenberg.utils import open_repository, open_or_init_repository, construct_keypair, ALGORITHMS
 
 
 @pytest.fixture
@@ -29,12 +29,10 @@ def Keypair() -> Mock:
         yield Keypair
 
 
-def test_open_repository():
-    path = 'test-path'
-    with pytest.assertRaises(ValueError) as e:
-        open_repository(path)
-
-    assert str(e.value) == f'{path} is not a valid repository path.'
+@pytest.fixture
+def MockPath() -> Mock:
+    with patch('battenberg.utils.Path') as MockPath:
+        yield MockPath
 
 
 def test_open_repository(Repository: Mock, discover_repository: Mock):
@@ -46,10 +44,8 @@ def test_open_repository(Repository: Mock, discover_repository: Mock):
 
 def test_open_repository_raises_on_invalid_path():
     path = 'test-path'
-    with pytest.raises(InvalidRepositoryException) as e:
+    with pytest.raises(InvalidRepositoryException, match=f'{path} is not a valid repository path.'):
         open_repository(path)
-
-    assert str(e.value) == f'{path} is not a valid repository path.'
 
 
 def test_open_or_init_repository_opens_repo(Repository: Mock, discover_repository: Mock):
@@ -61,7 +57,7 @@ def test_open_or_init_repository_opens_repo(Repository: Mock, discover_repositor
 
 
 def test_open_or_init_repository_initializes_repo(init_repository: Mock, Repository: Mock,
-        discover_repository: Mock):
+                                                  discover_repository: Mock):
     discover_repository.side_effect = Exception('No repo found')
 
     path = 'test-path'
@@ -81,8 +77,8 @@ def test_open_or_init_repository_initializes_repo(init_repository: Mock, Reposit
 
 
 @patch('battenberg.utils.subprocess')
-def test_open_or_init_repository_initializes_repo_with_inferred_initial_branch(subprocess: Mock,
-        init_repository: Mock, Repository: Mock, discover_repository: Mock):
+def test_open_or_init_repository_initializes_repo_with_inferred_initial_branch(
+        subprocess: Mock, init_repository: Mock, Repository: Mock, discover_repository: Mock):
     initial_branch = 'refs/heads/main'
     subprocess.run.return_value.stdout = f'ref: {initial_branch}    HEAD'
     discover_repository.side_effect = Exception('No repo found')
@@ -96,8 +92,9 @@ def test_open_or_init_repository_initializes_repo_with_inferred_initial_branch(s
 
 @pytest.mark.parametrize('stdout', ('', 'invalid-symref'))
 @patch('battenberg.utils.subprocess')
-def test_open_or_init_repository_initializes_repo_with_invalid_remote_branches(subprocess: Mock,
-        init_repository: Mock, Repository: Mock, discover_repository: Mock, stdout: str):
+def test_open_or_init_repository_initializes_repo_with_invalid_remote_branches(
+        subprocess: Mock, init_repository: Mock, Repository: Mock, discover_repository: Mock,
+        stdout: str):
     subprocess.run.return_value.stdout = stdout
     discover_repository.side_effect = Exception('No repo found')
 
@@ -107,16 +104,29 @@ def test_open_or_init_repository_initializes_repo_with_invalid_remote_branches(s
     assert open_or_init_repository(path, template) == repo
 
 
-def test_construct_keypair_defaults(Keypair: Mock):
+def test_construct_keypair_defaults(Keypair: Mock, MockPath: Mock, tmp_path: Path):
+    MockPath.return_value = tmp_path
+    public_key_path = tmp_path / 'id_rsa.pub'
+    public_key_path.touch()
+    private_key_path = tmp_path / 'id_rsa'
+    private_key_path.touch()
     construct_keypair()
-    user_home = os.path.expanduser('~')
-    Keypair.assert_called_once_with('git', f'{user_home}/.ssh/id_rsa.pub',
-                                    f'{user_home}/.ssh/id_rsa', '')
+    Keypair.assert_called_with('git', public_key_path,
+                               private_key_path, '')
 
 
-def test_construct_keypair(Keypair: Mock):
-    public_key_path = 'test-public_key_path'
-    private_key_path = 'test-private_key_path'
+@pytest.mark.parametrize('algorithm', ALGORITHMS.values())
+def test_construct_keypair(Keypair: Mock, tmp_path: Path, algorithm: dict):
+    public_key_path = tmp_path / algorithm['public']
+    public_key_path.touch()
+    private_key_path = tmp_path / algorithm['private']
+    private_key_path.touch()
     passphrase = 'test-passphrase'
     construct_keypair(public_key_path, private_key_path, passphrase)
-    Keypair.assert_called_once_with('git', public_key_path, private_key_path, passphrase)
+    Keypair.assert_called_with('git', public_key_path, private_key_path, passphrase)
+
+
+def test_construct_keypair_missing_key(MockPath: Mock, tmp_path: Path):
+    MockPath.return_value = tmp_path
+    with pytest.raises(KeypairException):
+        construct_keypair()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -116,13 +116,13 @@ def test_construct_keypair_defaults(Keypair: Mock, MockPath: Mock, tmp_path: Pat
 
 
 @pytest.mark.parametrize('algorithm', ALGORITHMS.values())
-def test_construct_keypair(Keypair: Mock, tmp_path: Path, algorithm: dict):
+def test_construct_keypair(Keypair: Mock, tmp_path: Path, algorithm: dict[str, Path]):
     public_key_path = tmp_path / algorithm['public']
     public_key_path.touch()
     private_key_path = tmp_path / algorithm['private']
     private_key_path.touch()
     passphrase = 'test-passphrase'
-    construct_keypair(public_key_path, private_key_path, passphrase)
+    construct_keypair(tmp_path, passphrase)
     Keypair.assert_called_with('git', public_key_path, private_key_path, passphrase)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from unittest.mock import Mock, patch
 import pytest
-from battenberg.errors import InvalidRepositoryException, KeypairException
+from battenberg.errors import InvalidRepositoryException, KeypairMissingException
 from battenberg.utils import open_repository, open_or_init_repository, construct_keypair, ALGORITHMS
 
 
@@ -128,5 +128,5 @@ def test_construct_keypair(Keypair: Mock, tmp_path: Path, algorithm: dict[str, P
 
 def test_construct_keypair_missing_key(MockPath: Mock, tmp_path: Path):
     MockPath.return_value = tmp_path
-    with pytest.raises(KeypairException):
+    with pytest.raises(KeypairMissingException):
         construct_keypair()


### PR DESCRIPTION
I use an ED25519 key, and was receiving this error message:
```
_pygit2.GitError: failed to authenticate SSH session: Unable to open public key file
```
Many types of keys are supported by Gitlab: https://docs.gitlab.com/ee/user/ssh.html#supported-ssh-key-types

This issue was that battenberg only looks for an RSA key!

This PR resolves that issue ~ and makes some minor improvements.